### PR TITLE
feat: add pet management features including CRUD operations, pet type…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.13",
         "axios": "^1.12.2",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
@@ -2217,6 +2218,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -3917,9 +3948,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001743",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
-      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4331,9 +4362,9 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6821,12 +6852,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/lru-cache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/lucide-react": {
       "version": "0.544.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
@@ -7699,6 +7724,13 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7893,13 +7925,6 @@
         "react": ">=16",
         "react-dom": ">=16"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -8717,9 +8742,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
+      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8729,6 +8754,16 @@
         "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -8853,9 +8888,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.20.5",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
-      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8873,9 +8908,9 @@
       }
     },
     "node_modules/tw-animate-css": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.8.tgz",
-      "integrity": "sha512-Qrk3PZ7l7wUcGYhwZloqfkWCmaXZAoqjkdbIDvzfGshwGtexa/DAs9koXxIkrpEasyevandomzCBAV1Yyop5rw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9280,14 +9315,10 @@
       "license": "ISC"
     },
     "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "axios": "^1.12.2",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,8 @@ datasource db {
 
 model pet_type {
   id              Int               @id @default(autoincrement())
-  pet_type_name   String            @db.VarChar(100)
+  pet_type_name   String            @unique @db.VarChar(100)
+  pets            pet[]
   sitter_pet_type sitter_pet_type[]
 }
 
@@ -60,6 +61,7 @@ model user {
   bank_number   String?     @db.VarChar(50)
   created_at    DateTime    @default(now()) @db.Timestamp(6)
   updated_at    DateTime?   @db.Timestamp(6)
+  pets          pet[]
   reviews       review[]
   sitter        sitter[]
   user_role     user_role[]
@@ -91,4 +93,26 @@ model review {
   created_at DateTime @default(now())
   sitter     sitter   @relation(fields: [sitter_id], references: [id], onDelete: Cascade)
   user       user     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+}
+
+model pet {
+  id          Int       @id @default(autoincrement())
+  owner_id    Int
+  pet_type_id Int
+  name        String    @db.VarChar(100)
+  breed       String    @db.VarChar(100)
+  sex         String    @db.VarChar(10)
+  age_month   Int
+  color       String    @db.VarChar(100)
+  weight_kg   Decimal   @db.Decimal(6, 2)
+  about       String?   @db.VarChar(1000)
+  image_url   String?   @db.VarChar(255)
+  created_at  DateTime  @default(now()) @db.Timestamp(6)
+  updated_at  DateTime? @db.Timestamp(6)
+  owner       user      @relation(fields: [owner_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  pet_type    pet_type  @relation(fields: [pet_type_id], references: [id], onUpdate: NoAction)
+
+  @@index([name], map: "idx_pet_name")
+  @@index([owner_id], map: "idx_pet_owner_id")
+  @@index([pet_type_id], map: "idx_pet_pet_type_id")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,4 @@
+// prisma/seed.ts
 import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
@@ -34,6 +35,21 @@ async function main() {
   } else {
     console.log('Pet Sitter role already exists')
   }
+
+  // -----------------------------
+  // Seed basic pet types (idempotent)
+  // หมายเหตุ: ตาราง pet_type มี unique(pet_type_name)
+  // ใช้ createMany + skipDuplicates เพื่อกันซ้ำ
+  // -----------------------------
+  const basePetTypes = ['Dog', 'Cat', 'Bird', 'Rabbit']
+  const toInsert = basePetTypes.map((name) => ({ pet_type_name: name }))
+
+  // ถ้าตารางมีอยู่แล้ว รันซ้ำจะข้ามตัวที่ซ้ำให้อัตโนมัติ
+  await prisma.pet_type.createMany({
+    data: toInsert,
+    skipDuplicates: true,
+  })
+  console.log('Ensured basic pet types:', basePetTypes.join(', '))
 
   console.log('Seed completed successfully!')
   console.log('Available roles:')

--- a/src/components/cards/BookingCard.tsx
+++ b/src/components/cards/BookingCard.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import Image from "next/image";
 
-export type Status = "waiting" | "in_service" | "success";
-export type Layout = "wide" | "compact";
-type ActionKey = "message" | "call" | "change" | "review" | "report";
 
-export interface Action {
+export type BookingStatus = "waiting" | "in_service" | "success";
+export type BookingLayout = "wide" | "compact";
+export type ActionKey = "message" | "call" | "change" | "review" | "report";
+
+
+export interface BookingAction {
   key: ActionKey;
   label?: string;
   onClick: () => void;
@@ -13,9 +15,8 @@ export interface Action {
 }
 
 export interface BookingCardProps {
-  /** wide = Desktop, compact = Mobile */
-  layout?: Layout;
-  status: Status;
+  layout?: BookingLayout;
+  status: BookingStatus;
   title: string;
   sitterName: string;
   avatarUrl?: string;
@@ -23,105 +24,130 @@ export interface BookingCardProps {
   dateTime: string;
   duration: string;
   pet: string;
-  /** ใช้กับ waiting / in_service */
   note?: string;
-  /** ใช้กับ success */
   successDate?: string;
-  actions?: Action[];
+  actions?: BookingAction[];
   className?: string;
 }
 
-const Icon = ({ d, className = "h-4 w-4" }: { d: string; className?: string }) => (
-  <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
-    <path d={d} />
-  </svg>
-);
 
-const icons = {
+const ICON_PATHS = {
   calendar:
     "M7 2h2v3H7V2Zm8 0h2v3h-2V2ZM3 8h18v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8Zm2-3h14a2 2 0 0 1 2 2v1H3V7a2 2 0 0 1 2-2Z",
-  clock: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 10V7h-2v7h6v-2h-4Z",
+  clock:
+    "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 10V7h-2v7h6v-2h-4Z",
   paw: "M12 13c3 0 6 1.7 6 4v2H6v-2c0-2.3 3-4 6-4Zm-5.2-6.6a1.8 1.8 0 1 1 0 3.6 1.8 1.8 0 0 1 0-3.6Zm10.4 0a1.8 1.8 0 1 1 0 3.6 1.8 1.8 0 0 1 0-3.6ZM9.5 3.5A2 2 0 1 1 7.5 6a2 2 0 0 1 2-2.5Zm5 0A2 2 0 1 1 12.5 6a2 2 0 0 1 2-2.5Z",
   phone:
     "M6.62 10.79a15 15 0 0 0 6.59 6.59l2.20-2.20a1 1 0 0 1 1.01-.24c1.12.37 2.33.57 3.58.57a1 1 0 0 1 1 1V21a1 1 0 0 1-1 1C10.07 22 2 13.93 2 3a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.25.2 2.46.57 3.58a1 1 0 0 1-.24 1.01l-2.21 2.2Z",
-  edit:
-    "M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25ZM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83Z",
-};
-
-const statusTokens = {
-  waiting: { dot: "bg-pink", text: "text-pink", label: "Waiting for confirm" },
-  in_service: { dot: "bg-blue", text: "text-blue", label: "In service" },
-  success: { dot: "bg-green", text: "text-green", label: "Success" },
+  edit: "M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25ZM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83Z",
 } as const;
 
-const Field: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-  <div>
-    <div className="text-[14px] font-medium leading-[22px] text-muted-text">{label}</div>
-    <div className="mt-1 text-[16px] font-medium leading-[24px] text-ink">{children}</div>
-  </div>
-);
+const STATUS_CONFIG = {
+  waiting: {
+    dot: "bg-pink",
+    text: "text-pink",
+    label: "Waiting for confirm",
+    bg: "bg-pink-bg",
+  },
+  in_service: {
+    dot: "bg-blue",
+    text: "text-blue",
+    label: "In service",
+    bg: "bg-blue-bg",
+  },
+  success: {
+    dot: "bg-green",
+    text: "text-green",
+    label: "Success",
+    bg: "bg-green-bg",
+  },
+} as const;
 
-const CallButton: React.FC<{ onClick: () => void; disabled?: boolean; strong?: boolean }> = ({
-  onClick,
-  disabled,
-  strong,
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    disabled={disabled}
-    aria-label="Call"
-    className={`grid h-12 w-12 place-items-center rounded-full ${
-      strong ? "bg-orange-1 text-orange-6" : "bg-orange-1/60 text-orange-6"
-    } disabled:opacity-50 hover:ring-2 hover:ring-orange-3 transition cursor-pointer`}
-  >
-    <Icon d={icons.phone} className="h-5 w-5" />
-  </button>
-);
-
-const GhostChangeBtn: React.FC<{ onClick: () => void; label?: string; disabled?: boolean }> = ({
-  onClick,
-  label = "Change",
-  disabled,
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    disabled={disabled}
-    className="inline-flex h-8 items-center gap-1 rounded-full px-3 text-[14px] font-medium text-orange-6 bg-white/0 hover:bg-orange-1/20 hover:shadow-sm transition disabled:opacity-50 cursor-pointer"
-  >
-    <Icon d={icons.edit} className="h-4 w-4" />
-    {label}
-  </button>
-);
-
-const OrangeBtn: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ className, children, ...rest }) => (
-  <button
-    {...rest}
-    className={`h-12 rounded-full bg-brand px-8 text-[16px] font-bold text-white hover:brightness-95 hover:shadow-md transition disabled:opacity-50 cursor-pointer ${className || ""}`}
-  >
-    {children}
-  </button>
-);
+const STYLES = {
+  card: {
+    base:
+      "group rounded-2xl border border-border bg-card shadow-sm transition hover:shadow-md hover:ring-1 ring-brand",
+    desktop: "w-full p-6",
+    mobile: "w-[375px] p-5",
+  },
+  button: {
+    primary:
+      "h-12 rounded-full bg-brand text-[16px] font-bold text-brand-text hover:brightness-95 hover:shadow-md transition disabled:opacity-50 cursor-pointer px-8",
+    call:
+      "grid h-12 w-12 place-items-center rounded-full hover:ring-2 hover:ring-brand transition cursor-pointer",
+    ghost:
+      "inline-flex h-8 items-center gap-1 rounded-full px-3 text-[14px] font-medium text-orange-6 bg-white/0 hover:bg-orange-1/20 hover:shadow-sm transition disabled:opacity-50 cursor-pointer",
+    report:
+      "text-[16px] font-bold leading-[24px] text-orange-6 hover:opacity-80 transition cursor-pointer",
+  },
+  text: {
+    title: "text-[16px] font-bold text-ink",
+    subtitle: "text-[12px] text-muted-text",
+    label: "text-[14px] font-medium text-muted-text",
+    value: "text-[16px] font-medium leading-[24px] text-ink",
+    transaction: "text-[12px] text-muted-text",
+  },
+  divider: "h-px bg-border",
+  separator: "h-10 w-px bg-border/60",
+} as const;
 
 
-const Avatar: React.FC<{ src: string; alt: string; size: number; ring?: boolean }> = ({ src, alt, size, ring }) => (
-  <div
-    className={`relative overflow-hidden rounded-full ${ring ? "ring-1 ring-border" : ""}`}
-    style={{ width: size, height: size }}
-    aria-hidden
-  >
-    <Image src={src} alt={alt} fill sizes={`${size}px`} className="object-cover" />
-  </div>
-);
 
-const splitDateTime = (s: string) => {
-  const [left, right] = s.split("|").map((v) => v.trim());
+const parseDateTime = (dateTime: string) => {
+  const [left, right] = dateTime.split("|").map((part) => part.trim());
   return { left, right };
 };
 
-const renderDateTime = (s: string) => {
-  const { left, right } = splitDateTime(s);
+const useActionsLookup = (actions?: BookingAction[]) =>
+  React.useMemo(() => {
+    const map = new Map<ActionKey, BookingAction>();
+    actions?.forEach((a) => map.set(a.key, a));
+    return {
+      get: (k: ActionKey) => map.get(k),
+      message: map.get("message"),
+      call: map.get("call"),
+      change: map.get("change"),
+      review: map.get("review"),
+      report: map.get("report"),
+    };
+  }, [actions]);
+
+
+const Icon: React.FC<{ path: string; className?: string }> = React.memo(
+  ({ path, className = "h-4 w-4" }) => (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d={path} />
+    </svg>
+  )
+);
+Icon.displayName = "Icon";
+
+
+const Avatar: React.FC<{ src: string; alt: string; size: number; showRing?: boolean }> = React.memo(
+  ({ src, alt, size, showRing = true }) => (
+    <div
+      className={`relative overflow-hidden rounded-full ${showRing ? "ring-1 ring-border" : ""}`}
+      style={{ width: size, height: size }}
+    >
+      <Image src={src} alt={alt} width={size} height={size} className="object-cover" />
+    </div>
+  )
+);
+Avatar.displayName = "Avatar";
+
+const StatusBadge: React.FC<{ status: BookingStatus }> = React.memo(({ status }) => {
+  const config = STATUS_CONFIG[status];
+  return (
+    <div className={`inline-flex items-center gap-2 text-[12px] ${config.text}`}>
+      <span className={`h-2 w-2 rounded-full ${config.dot}`} />
+      {config.label}
+    </div>
+  );
+});
+StatusBadge.displayName = "StatusBadge";
+
+const FormattedDateTime: React.FC<{ dateTime: string }> = React.memo(({ dateTime }) => {
+  const { left, right } = React.useMemo(() => parseDateTime(dateTime), [dateTime]);
   return (
     <span className="text-ink">
       {left}
@@ -129,230 +155,272 @@ const renderDateTime = (s: string) => {
       {right}
     </span>
   );
-};
+});
+FormattedDateTime.displayName = "FormattedDateTime";
 
-const pick = (actions: Action[] | undefined, key: ActionKey) => actions?.find((a) => a.key === key);
+const InfoField: React.FC<{ label: string; children: React.ReactNode }> = React.memo(
+  ({ label, children }) => (
+    <div>
+      <div className={STYLES.text.label}>{label}</div>
+      <div className={`mt-1 ${STYLES.text.value}`}>{children}</div>
+    </div>
+  )
+);
+InfoField.displayName = "InfoField";
 
-export const BookingCard: React.FC<BookingCardProps> = ({
-  layout = "wide",
-  status,
-  title,
-  sitterName,
-  avatarUrl,
-  transactionDate,
-  dateTime,
-  duration,
-  pet,
-  note,
-  successDate,
-  actions = [],
-  className = "",
-}) => {
-  const isDesktop = layout === "wide";
-  const tok = statusTokens[status];
+const CallButton: React.FC<{ onClick: () => void; disabled?: boolean; strong?: boolean }> = React.memo(
+  ({ onClick, disabled, strong }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Call"
+      className={`${STYLES.button.call} ${strong ? "bg-orange-1 text-orange-6" : "bg-orange-1/60 text-orange-6"} disabled:opacity-50`}
+    >
+      <Icon path={ICON_PATHS.phone} className="h-5 w-5" />
+    </button>
+  )
+);
+CallButton.displayName = "CallButton";
 
-  const actMessage = pick(actions, "message");
-  const actChange = pick(actions, "change");
-  const actReport = pick(actions, "report");
-  const actReview = pick(actions, "review");
-  const actCall = pick(actions, "call");
+const ChangeButton: React.FC<{ onClick: () => void; label?: string; disabled?: boolean }> = React.memo(
+  ({ onClick, label = "Change", disabled }) => (
+    <button type="button" onClick={onClick} disabled={disabled} className={STYLES.button.ghost}>
+      <Icon path={ICON_PATHS.edit} className="h-4 w-4" />
+      {label}
+    </button>
+  )
+);
+ChangeButton.displayName = "ChangeButton";
 
-  /* ------------- DESKTOP ------------- */
-  if (isDesktop) {
+const PrimaryButton: React.FC<{ onClick: () => void; children: React.ReactNode; disabled?: boolean; className?: string }> =
+  React.memo(({ onClick, children, disabled, className = "" }) => (
+    <button type="button" onClick={onClick} disabled={disabled} className={`${STYLES.button.primary} ${className}`}>
+      {children}
+    </button>
+  ));
+PrimaryButton.displayName = "PrimaryButton";
+
+
+const WaitingSection: React.FC<{
+  note?: string;
+  actions: BookingAction[];
+  isDesktop: boolean;
+  status?: BookingStatus;
+}> = React.memo(({ note, actions, isDesktop, status = "waiting" }) => {
+  const cfg = STATUS_CONFIG[status];
+  const { message: messageAction, call: callAction } = useActionsLookup(actions);
+
+  if (!note && !messageAction && !callAction) return null;
+
+  return (
+    <div className={`mt-6 rounded-xl p-4 ring-1 ring-border ${cfg.bg}`}>
+      <div className={`flex items-center ${isDesktop ? "" : "flex-col gap-3"}`}>
+        {note && (
+          <div className={`text-[14px] font-medium leading-[22px] text-muted-text ${isDesktop ? "grow" : ""}`}>
+            {note}
+          </div>
+        )}
+        <div className="flex items-center gap-3">
+          {messageAction && (
+            <PrimaryButton onClick={messageAction.onClick} disabled={messageAction.disabled} className={isDesktop ? "" : "px-6 text-[14px]"}>
+              {messageAction.label || "Send Message"}
+            </PrimaryButton>
+          )}
+          {callAction && <CallButton onClick={callAction.onClick} disabled={callAction.disabled} strong />}
+        </div>
+      </div>
+    </div>
+  );
+});
+WaitingSection.displayName = "WaitingSection";
+
+const SuccessSection: React.FC<{ successDate: string; actions: BookingAction[]; isDesktop: boolean }> = React.memo(
+  ({ successDate, actions, isDesktop }) => {
+    const { report: reportAction, review: reviewAction, call: callAction } = useActionsLookup(actions);
+
     return (
-      <div
-        className={`group w-full rounded-2xl border border-border bg-white p-6 shadow-sm transition hover:shadow-md hover:ring-1 hover:ring-blue-300 ${className}`}
-      >
-
-        <div className="flex items-start gap-3">
-          {avatarUrl && <Avatar src={avatarUrl} alt={sitterName} size={64} ring />}
-          <div className="min-w-0 flex-1">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <h3 className="truncate text-[16px] font-bold text-ink">{title}</h3>
-                <p className="truncate text-[12px] text-muted-text">By {sitterName}</p>
-              </div>
-              <div className="text-right">
-                <div className="text-[12px] text-muted-text">Transaction date: {transactionDate}</div>
-                <div className={`mt-1 inline-flex items-center gap-2 text-[12px] ${tok.text}`}>
-                  <span className={`h-2 w-2 rounded-full ${tok.dot}`} />
-                  {tok.label}
-                </div>
-              </div>
-            </div>
+      <div className="mt-6 rounded-xl p-4 ring-1 ring-green/60 bg-green-bg">
+        <div className={`flex items-center ${isDesktop ? "" : "flex-col gap-3"}`}>
+          <div className={isDesktop ? "grow" : ""}>
+            <div className="text-[14px] font-medium leading-[24px] text-green">Success date:</div>
+            <div className="text-[14px] font-medium leading-[24px] text-green">{successDate}</div>
+          </div>
+          <div className="flex items-center gap-6">
+            {reportAction && (
+              <button onClick={reportAction.onClick} disabled={reportAction.disabled} className={STYLES.button.report}>
+                {reportAction.label || "Report"}
+              </button>
+            )}
+            {reviewAction && <PrimaryButton onClick={reviewAction.onClick} disabled={reviewAction.disabled}>{reviewAction.label || "Review"}</PrimaryButton>}
+            {callAction && <CallButton onClick={callAction.onClick} disabled={callAction.disabled} strong />}
           </div>
         </div>
-
-        {/* Divider */}
-        <div className="my-5 h-px bg-border" />
-
-        <div className="flex items-start">
-          <div className="flex-1 pr-6">
-            <div className="flex items-center justify-between">
-              <div className="text-[14px] font-medium text-muted-text">Date &amp; Time:</div>
-              {status === "waiting" && actChange && (
-                <GhostChangeBtn
-                  onClick={actChange.onClick}
-                  label={actChange.label || "Change"}
-                  disabled={actChange.disabled}
-                />
-              )}
-            </div>
-            <div className="mt-1 text-[16px] leading-[24px] text-ink">{renderDateTime(dateTime)}</div>
-          </div>
-
-          <div className="mx-6 h-10 w-px bg-border/60" />
-
-          <div className="flex-1 pr-6">
-            <Field label="Duration:">{duration}</Field>
-          </div>
-
-          <div className="mx-6 h-10 w-px bg-border/60" />
-
-          <div className="flex-1">
-            <Field label="Pet:">{pet}</Field>
-          </div>
-        </div>
-
-        {(status === "waiting" || status === "in_service") && (
-          <div className="mt-6 rounded-xl bg-[#F6F6F9] p-4 ring-1 ring-border">
-            <div className="flex items-center">
-              <div className="grow text-[14px] font-medium leading-[22px] text-muted-text">{note}</div>
-              <div className="flex items-center gap-3">
-                {actMessage && (
-                  <OrangeBtn onClick={actMessage.onClick} disabled={actMessage.disabled}>
-                    {actMessage.label || "Send Message"}
-                  </OrangeBtn>
-                )}
-                {actCall && <CallButton onClick={actCall.onClick} disabled={actCall.disabled} strong />}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {status === "success" && successDate && (
-          <div className="mt-6 rounded-xl bg-[#E9FFF6] p-4 ring-1 ring-green/60">
-            <div className="flex items-center">
-              <div className="grow">
-                <div className="text-[14px] font-medium leading-[24px] text-green">Success date:</div>
-                <div className="text-[14px] font-medium leading-[24px] text-green">{successDate}</div>
-              </div>
-              <div className="flex items-center gap-6">
-                {actReport && (
-                  <button
-                    onClick={actReport.onClick}
-                    disabled={actReport.disabled}
-                    className="text-[16px] font-bold leading-[24px] text-orange-6 hover:opacity-80 transition cursor-pointer"
-                  >
-                    {actReport.label || "Report"}
-                  </button>
-                )}
-                {actReview && (
-                  <OrangeBtn onClick={actReview.onClick} disabled={actReview.disabled}>
-                    {actReview.label || "Review"}
-                  </OrangeBtn>
-                )}
-                {actCall && <CallButton onClick={actCall.onClick} disabled={actCall.disabled} strong />}
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     );
   }
+);
+SuccessSection.displayName = "SuccessSection";
 
-  /* ------------- MOBILE ------------- */
+
+const DesktopLayout: React.FC<BookingCardProps> = React.memo((props) => {
+  const {
+    status,
+    title,
+    sitterName,
+    avatarUrl,
+    transactionDate,
+    dateTime,
+    duration,
+    pet,
+    note,
+    successDate,
+    actions = [],
+    className = "",
+  } = props;
+
+  const { change: changeAction } = useActionsLookup(actions);
+
   return (
-    <div
-      className={`group w-[375px] rounded-2xl border border-border bg-white p-5 shadow-sm transition hover:shadow-md hover:ring-1 hover:ring-blue-300 ${className}`}
-    >
+    <div className={`${STYLES.card.base} ${STYLES.card.desktop} ${className}`}>
+      <div className="flex items-start gap-3">
+        {avatarUrl && <Avatar src={avatarUrl} alt={sitterName} size={64} />}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h3 className={`truncate ${STYLES.text.title}`}>{title}</h3>
+              <p className={`truncate ${STYLES.text.subtitle}`}>By {sitterName}</p>
+            </div>
+            <div className="text-right">
+              <div className={STYLES.text.transaction}>Transaction date: {transactionDate}</div>
+              <div className="mt-1">
+                <StatusBadge status={status} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+  
+      <div className={`my-5 ${STYLES.divider}`} />
+
+  
+      <div className="flex items-start">
+        <div className="flex-1 pr-6">
+          <div className="flex items-center justify-between">
+            <div className={STYLES.text.label}>Date &amp; Time:</div>
+            {status === "waiting" && changeAction && (
+              <ChangeButton onClick={changeAction.onClick} label={changeAction.label} disabled={changeAction.disabled} />
+            )}
+          </div>
+          <div className={`mt-1 ${STYLES.text.value}`}>
+            <FormattedDateTime dateTime={dateTime} />
+          </div>
+        </div>
+
+        <div className={`mx-6 ${STYLES.separator}`} />
+
+        <div className="flex-1 pr-6">
+          <InfoField label="Duration:">{duration}</InfoField>
+        </div>
+
+        <div className={`mx-6 ${STYLES.separator}`} />
+
+        <div className="flex-1">
+          <InfoField label="Pet:">{pet}</InfoField>
+        </div>
+      </div>
+
+ 
+      {(status === "waiting" || status === "in_service") && (
+        <WaitingSection note={note} actions={actions} isDesktop={true} status={status} />
+      )}
+
+      {status === "success" && successDate && <SuccessSection successDate={successDate} actions={actions} isDesktop={true} />}
+    </div>
+  );
+});
+DesktopLayout.displayName = "DesktopLayout";
+
+const MobileLayout: React.FC<BookingCardProps> = React.memo((props) => {
+  const {
+    status,
+    title,
+    sitterName,
+    avatarUrl,
+    transactionDate,
+    dateTime,
+    duration,
+    pet,
+    note,
+    successDate,
+    actions = [],
+    className = "",
+  } = props;
+
+  const { change: changeAction } = useActionsLookup(actions);
+
+  return (
+    <div className={`${STYLES.card.base} ${STYLES.card.mobile} ${className}`}>
       <div className="flex flex-col gap-3">
         {/* Avatar + Title */}
         <div className="flex gap-3">
-          {avatarUrl && <Avatar src={avatarUrl} alt={sitterName} size={36} ring />}
+          {avatarUrl && <Avatar src={avatarUrl} alt={sitterName} size={36} />}
           <div className="flex flex-col">
             <div className="truncate text-[18px] leading-[24px] font-bold text-ink">{title}</div>
             <div className="truncate text-[14px] leading-[22px] font-medium text-ink">By {sitterName}</div>
           </div>
         </div>
 
+
         <div>
-          <div className="text-[14px] font-medium text-muted-text">Transaction date: {transactionDate}</div>
-          <div className={`mt-1 inline-flex items-center gap-2 text-[16px] leading-[24px] font-medium ${tok.text}`}>
-            <span className={`h-2 w-2 rounded-full ${tok.dot}`} />
-            {tok.label}
+          <div className={STYLES.text.transaction}>Transaction date: {transactionDate}</div>
+          <div className="mt-1">
+            <StatusBadge status={status} />
           </div>
 
-          <div className="mt-3 h-px bg-border" />
+          <div className={`mt-3 ${STYLES.divider}`} />
+
 
           <div className="mt-4 space-y-5">
             <div>
               <div className="flex items-center justify-between">
                 <div className="inline-flex items-center gap-2 text-[14px] font-medium leading-[22px] text-muted-text">
-                  <Icon d={icons.calendar} className="h-4 w-4 text-muted-text" />
+                  <Icon path={ICON_PATHS.calendar} className="h-4 w-4 text-muted-text" />
                   Date &amp; Time:
                 </div>
-                {status === "waiting" && actChange && (
-                  <GhostChangeBtn
-                    onClick={actChange.onClick}
-                    label={actChange.label || "Change"}
-                    disabled={actChange.disabled}
-                  />
+                {status === "waiting" && changeAction && (
+                  <ChangeButton onClick={changeAction.onClick} label={changeAction.label} disabled={changeAction.disabled} />
                 )}
               </div>
-              <div className="mt-1 text-[16px] font-medium leading-[28px] text-ink">{renderDateTime(dateTime)}</div>
+              <div className="mt-1 text-[16px] font-medium leading-[28px] text-ink">
+                <FormattedDateTime dateTime={dateTime} />
+              </div>
             </div>
 
-            <Field label="Duration:">{duration}</Field>
-            <Field label="Pet:">{pet}</Field>
+            <InfoField label="Duration:">{duration}</InfoField>
+            <InfoField label="Pet:">{pet}</InfoField>
           </div>
         </div>
       </div>
 
+
       {(status === "waiting" || status === "in_service") && (
-        <div className="mx-auto mt-4 w-full rounded-xl bg-[#F6F6F9] p-4 ring-1 ring-border">
-          <div className="text-[14px] font-medium leading-[22px] text-muted-text">{note}</div>
-          <div className="mt-3 flex items-center">
-            <div className="flex items-center gap-2">
-              {actMessage && (
-                <OrangeBtn onClick={actMessage.onClick} disabled={actMessage.disabled} className="px-6 text-[14px]">
-                  {actMessage.label || "Send Message"}
-                </OrangeBtn>
-              )}
-            </div>
-            {actCall && <CallButton onClick={actCall.onClick} disabled={actCall.disabled} strong />}
-          </div>
-        </div>
+        <WaitingSection note={note} actions={actions} isDesktop={false} status={status} />
       )}
 
-      {status === "success" && successDate && (
-        <div className="mx-auto mt-4 w-full rounded-xl bg-[#E9FFF6] p-4 ring-1 ring-green/60">
-          <div className="text-[14px] font-medium leading-[24px] text-green">Success date:</div>
-          <div className="text-[14px] font-medium leading-[24px] text-green">{successDate}</div>
-
-          <div className="mt-3 flex items-center">
-            <div className="flex items-center gap-6">
-              {actReport && (
-                <button
-                  onClick={actReport.onClick}
-                  disabled={actReport.disabled}
-                  className="text-[16px] font-bold leading-[24px] text-orange-6 hover:opacity-80 transition cursor-pointer"
-                >
-                  {actReport.label || "Report"}
-                </button>
-              )}
-              {actReview && (
-                <OrangeBtn onClick={actReview.onClick} disabled={actReview.disabled}>
-                  {actReview.label || "Review"}
-                </OrangeBtn>
-              )}
-            </div>
-            {actCall && <CallButton onClick={actCall.onClick} disabled={actCall.disabled} strong />}
-          </div>
-        </div>
-      )}
+      {status === "success" && successDate && <SuccessSection successDate={successDate} actions={actions} isDesktop={false} />}
     </div>
   );
-};
+});
+MobileLayout.displayName = "MobileLayout";
+
+
+export const BookingCard: React.FC<BookingCardProps> = React.memo((props) => {
+  const { layout = "wide" } = props;
+  const isDesktop = layout === "wide";
+  return isDesktop ? <DesktopLayout {...props} /> : <MobileLayout {...props} />;
+});
+BookingCard.displayName = "BookingCard";
 
 export default BookingCard;

--- a/src/components/cards/CreateNewPetCard.tsx
+++ b/src/components/cards/CreateNewPetCard.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  height?: number;
+};
+
+
+const THEME_COLORS = {
+  border: "border-orange-100/70",
+  background: "bg-orange-50/60 hover:bg-orange-50",
+  icon: "border-orange-400",
+  text: "text-orange-500"
+} as const;
+
+const STYLES = {
+  button: `
+    group grid w-full place-items-center rounded-3xl border
+    cursor-pointer transition p-8 text-center
+  `,
+  iconContainer: "grid h-14 w-14 place-items-center rounded-full border-2",
+  icon: "text-2xl leading-none",
+  label: "font-semibold",
+  content: "mx-auto grid place-items-center gap-3"
+} as const;
+
+const DEFAULT_HEIGHT = 260;
+
+
+export default function CreateNewPetCard({
+  onClick,
+  className,
+  height = DEFAULT_HEIGHT,
+  style,
+  ...rest
+}: Props) {
+  const buttonStyles = cn(
+    STYLES.button,
+    THEME_COLORS.border,
+    THEME_COLORS.background,
+    className
+  );
+
+  const iconContainerStyles = cn(
+    STYLES.iconContainer,
+    THEME_COLORS.icon
+  );
+
+  const textStyles = cn(
+    STYLES.icon,
+    THEME_COLORS.text
+  );
+
+  const labelStyles = cn(
+    STYLES.label,
+    THEME_COLORS.text
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{ minHeight: height, ...style }}
+      className={buttonStyles}
+      aria-label="Create New Pet"
+      {...rest}
+    >
+      <div className={STYLES.content}>
+        <div className={iconContainerStyles}>
+          <span className={textStyles}>+</span>
+        </div>
+        
+        <div className={labelStyles}>
+          Create New Pet
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/cards/PetCard.tsx
+++ b/src/components/cards/PetCard.tsx
@@ -2,54 +2,183 @@ import * as React from "react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 
-type Species = "Cat" | "Dog" | "Bird" | "Rabbit" | (string & {});
+
+export type PetSpecies = "Cat" | "Dog" | "Bird" | "Rabbit" | (string & {});
 
 export type PetCardProps = {
+
+  id?: number;
   name: string;
-  species: Species;
-  img: string;
+  species: PetSpecies;
+  img?: string;
   selected?: boolean;
   disabled?: boolean;
   className?: string;
+
   onClick?: () => void;
-
-
+  onClickId?: (id: number) => void;
   size?: number;
   width?: number;
   height?: number;
-
-
   avatarSize?: number;
 };
 
-const AVATAR_MIN = 64;
-const AVATAR_MAX = 128;
-const AVATAR_RATIO = 0.5; 
 
-const CHIP_STYLES: Record<string, string> = {
+const AVATAR_CONFIG = {
+  MIN: 64,
+  MAX: 128,
+  RATIO: 0.5,
+  BASE_SIZE: 240,
+} as const;
+
+const DEFAULT_CARD_SIZE = 240;
+
+const SPECIES_STYLES: Record<string, string> = {
   Dog: "bg-green-bg text-success ring-success",
   Cat: "bg-pink-bg text-pink ring-pink",
   Bird: "bg-blue-bg text-blue ring-blue",
   Rabbit: "bg-orange-1 text-orange-6 ring-orange-2",
-  __: "bg-muted text-muted-text ring-border",
+  default: "bg-muted text-muted-text ring-border",
+} as const;
+
+const CARD_STYLES = {
+  base: `
+    relative flex flex-col items-center gap-4 bg-white p-6 transition
+    rounded-[16px] border
+  `,
+  selected: "border-brand",
+  unselected: "border-border",
+  disabled: "cursor-not-allowed opacity-40",
+  interactive: `
+    cursor-pointer 
+    hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] 
+    active:scale-[.99]
+  `,
+  chip: `
+    inline-flex h-8 items-center justify-center rounded-full 
+    px-3 text-[13px] font-medium ring-1 ring-inset
+  `,
+  selectedBadge: `
+    absolute right-6 top-6 inline-flex h-6 w-6 items-center 
+    justify-center rounded-md bg-brand text-brand-text shadow-sm
+  `,
+  avatar: `
+    relative shrink-0 overflow-hidden rounded-full bg-muted 
+    flex items-center justify-center
+  `,
+  petName: "text-[20px] font-semibold leading-6 text-ink text-center",
+  noImage: "text-muted-text text-sm",
+} as const;
+
+
+const calculateAvatarSize = (cardHeight: number, customAvatarSize?: number): number => {
+  if (customAvatarSize) {
+    return Math.max(AVATAR_CONFIG.MIN, Math.min(AVATAR_CONFIG.MAX, customAvatarSize));
+  }
+  const autoSize = Math.round(Math.min(AVATAR_CONFIG.BASE_SIZE, cardHeight) * AVATAR_CONFIG.RATIO);
+  const clampedSize = Math.max(AVATAR_CONFIG.MIN, Math.min(AVATAR_CONFIG.MAX, autoSize));
+  return clampedSize % 2 === 0 ? clampedSize : clampedSize + 1; // even for crisper rendering
 };
 
-const Chip: React.FC<{ label: string }> = React.memo(({ label }) => {
-  const chipColor = CHIP_STYLES[label] ?? CHIP_STYLES.__;
+const getSpeciesStyle = (species: string): string => {
+  return SPECIES_STYLES[species] ?? SPECIES_STYLES.default;
+};
+
+
+const SpeciesChip: React.FC<{ species: string }> = React.memo(({ species }) => {
+  const chipStyle = getSpeciesStyle(species);
+  return <span className={cn(CARD_STYLES.chip, chipStyle)}>{species}</span>;
+});
+SpeciesChip.displayName = "SpeciesChip";
+
+const SelectedBadge: React.FC = React.memo(() => (
+  <span className={CARD_STYLES.selectedBadge}>
+    <svg viewBox="0 0 24 24" aria-hidden className="h-4 w-4">
+      <path fill="currentColor" d="M9.55 17.05 4.5 12l1.41-1.41 3.64 3.64 8.54-8.54L19.5 7.1z" />
+    </svg>
+  </span>
+));
+SelectedBadge.displayName = "SelectedBadge";
+
+const PetAvatar: React.FC<{
+  src: string;
+  name: string;
+  size: number;
+  onError: () => void;
+}> = React.memo(({ src, name, size, onError }) => {
+  const hasImage = src.trim().length > 0;
   return (
-    <span
-      className={cn(
-        "inline-flex h-8 items-center justify-center rounded-full px-3 text-[13px] font-medium ring-1 ring-inset",
-        chipColor
+    <div style={{ width: size, height: size }} className={CARD_STYLES.avatar} aria-hidden>
+      {hasImage ? (
+        <Image
+          src={src}
+          alt={name}
+          fill
+          sizes={`${size}px`}
+          className="object-cover"
+          loading="lazy"
+          decoding="async"
+          onError={onError}
+        />
+      ) : (
+        <span className={CARD_STYLES.noImage}>No image</span>
       )}
-    >
-      {label}
-    </span>
+    </div>
   );
 });
-Chip.displayName = "Chip";
+PetAvatar.displayName = "PetAvatar";
 
-export default function PetCard({
+
+const useImageState = (initialImage?: string) => {
+  const [imageSrc, setImageSrc] = React.useState<string>((initialImage ?? "").trim());
+
+  React.useEffect(() => {
+    setImageSrc((initialImage ?? "").trim());
+  }, [initialImage]);
+
+  const handleImageError = React.useCallback(() => setImageSrc(""), []);
+
+  return { imageSrc, handleImageError };
+};
+
+const useCardDimensions = (size: number, width?: number, height?: number) =>
+  React.useMemo(
+    () => ({
+      width: width ?? "100%",
+      minHeight: height ?? size,
+    }),
+    [size, width, height]
+  );
+
+/** รวม handler เดียวให้คลิก/กดแป้นทำงาน */
+const useUnifiedInteraction = (
+  disabled: boolean,
+  id: number | undefined,
+  onClick?: () => void,
+  onClickId?: (id: number) => void
+) => {
+  const handle = React.useCallback(() => {
+    if (disabled) return;
+    if (onClickId && typeof id === "number") onClickId(id);
+    else onClick?.();
+  }, [disabled, id, onClick, onClickId]);
+
+  const handleKey = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (disabled) return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handle();
+      }
+    },
+    [disabled, handle]
+  );
+
+  return { handleClick: handle, handleKeyDown: handleKey };
+};
+
+function PetCard({
+  id,
   name,
   species,
   img,
@@ -57,72 +186,52 @@ export default function PetCard({
   disabled = false,
   className,
   onClick,
-  size = 240,
+  onClickId,
+  size = DEFAULT_CARD_SIZE,
   width,
   height,
   avatarSize,
 }: PetCardProps) {
-  const boxW = width ?? size;
-  const boxH = height ?? size;
+  const dimensions = useCardDimensions(size, width, height);
+  const { imageSrc, handleImageError } = useImageState(img);
+  const { handleClick, handleKeyDown } = useUnifiedInteraction(disabled, id, onClick, onClickId);
 
-  const autoAvatar = Math.round(Math.min(boxW, boxH) * AVATAR_RATIO);
-  const avatar = Math.max(AVATAR_MIN, Math.min(AVATAR_MAX, avatarSize ?? autoAvatar));
-  const evenAvatar = avatar % 2 === 0 ? avatar : avatar + 1;
+  const calculatedAvatarSize = React.useMemo(
+    () => calculateAvatarSize(dimensions.minHeight as number, avatarSize),
+    [dimensions.minHeight, avatarSize]
+  );
 
-  const handleClick = React.useCallback(() => {
-    if (!disabled) onClick?.();
-  }, [disabled, onClick]);
+  const cardClassName = cn(
+    CARD_STYLES.base,
+    selected ? CARD_STYLES.selected : CARD_STYLES.unselected,
+    disabled ? CARD_STYLES.disabled : CARD_STYLES.interactive,
+    className
+  );
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      style={{ width: boxW, height: boxH } as React.CSSProperties}
-      className={cn(
-        "relative flex flex-col items-center gap-4 bg-white p-6 transition",
-        "rounded-[16px] border",
-        selected ? "border-brand" : "border-border",
-        disabled
-          ? "cursor-not-allowed opacity-40"
-          : "cursor-pointer hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] active:scale-[.99]",
-        className
-      )}
+      onKeyDown={handleKeyDown}
+      style={dimensions as React.CSSProperties}
+      className={cardClassName}
       aria-pressed={selected}
       aria-disabled={disabled}
       role="button"
+      title={`${name} • ${species}`}
       data-state={selected ? "selected" : "default"}
       data-disabled={disabled ? "true" : "false"}
     >
-      {selected && (
-        <span className="absolute right-6 top-6 inline-flex h-6 w-6 items-center justify-center rounded-md bg-brand text-brand-text shadow-sm">
-          <svg viewBox="0 0 24 24" aria-hidden className="h-4 w-4">
-            <path
-              fill="currentColor"
-              d="M9.55 17.05 4.5 12l1.41-1.41 3.64 3.64 8.54-8.54L19.5 7.1z"
-            />
-          </svg>
-        </span>
-      )}
+      {selected && <SelectedBadge />}
 
+      <PetAvatar src={imageSrc} name={name} size={calculatedAvatarSize} onError={handleImageError} />
 
-      <div
-        style={{ width: evenAvatar, height: evenAvatar }}
-        className="relative shrink-0 overflow-hidden rounded-full bg-muted"
-        aria-hidden
-      >
-        <Image
-          src={img}
-          alt={name}
-          fill
-          sizes={`${evenAvatar}px`}
-          className="object-cover"
-          loading="lazy"
-          decoding="async"
-        />
-      </div>
+      <p className={CARD_STYLES.petName}>{name}</p>
 
-      <p className="text-[20px] font-semibold leading-6 text-ink text-center">{name}</p>
-      <Chip label={species} />
+      <SpeciesChip species={species} />
     </button>
   );
 }
+
+
+export default React.memo(PetCard);

--- a/src/components/cards/PetSitterCard.tsx
+++ b/src/components/cards/PetSitterCard.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
 import Image from "next/image";
 
-type Size = "lg" | "sm";
-type Variant = "default" | "chips" | "compact";
-type SmPreset = "wide" | "compact";
-type LgLayout = "side" | "cover";
+
+export type CardSize = "lg" | "sm";
+export type CardVariant = "default" | "chips" | "compact";
+export type SmallPreset = "wide" | "compact";
+export type LargeLayout = "side" | "cover";
 
 export type PetSitterCardProps = {
-  size?: Size;
-  variant?: Variant;
+  size?: CardSize;
+  variant?: CardVariant;
   title: string;
   hostName: string;
   location: string;
@@ -17,16 +18,61 @@ export type PetSitterCardProps = {
   coverUrl: string;
   avatarUrl?: string;
   showAvatar?: boolean;
-  smPreset?: SmPreset;
-  lgLayout?: LgLayout;
+  smPreset?: SmallPreset;
+  lgLayout?: LargeLayout;
   className?: string;
 };
 
-function cn(...classes: (string | undefined | false | null)[]) {
-  return classes.filter(Boolean).join(" ");
-}
 
-const IconLocation = ({ className = "h-4 w-4" }: { className?: string }) => (
+const TAG_COLORS = {
+  Dog: "bg-green-bg text-success ring-success",
+  Cat: "bg-pink-bg text-pink ring-pink",
+  Bird: "bg-blue-bg text-blue ring-blue",
+  Rabbit: "bg-orange-1 text-orange-4 ring-orange-4",
+  default: "bg-muted text-muted-text ring-border",
+} as const;
+
+const RATING_SIZES = {
+  xs: "h-3 w-3",
+  sm: "h-[14px] w-[14px]",
+  md: "h-5 w-5",
+} as const;
+
+const CARD_STYLES = {
+  base: `
+    group cursor-pointer rounded-2xl border border-border bg-white
+    hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] 
+    focus-visible:outline-none
+  `,
+  tag: `
+    inline-flex h-8 items-center rounded-full px-3 text-[14px] 
+    font-medium ring-1 ring-inset whitespace-nowrap shrink-0
+  `,
+  title: {
+    lg: "text-[24px] leading-8 font-semibold text-ink",
+    md: "text-[20px] leading-7 font-semibold text-ink",
+  },
+  subtitle: "text-[14px] leading-5 text-muted-text",
+  location: "flex items-center gap-1 text-muted-text",
+  locationText: "truncate text-[14px] leading-5",
+  tagContainer: "flex flex-row flex-wrap items-center gap-2",
+  avatar: {
+    sm: "h-9 w-9 rounded-full object-cover",
+    md: "h-10 w-10 rounded-full object-cover",
+  },
+  image: "h-full w-full object-cover",
+  imageContainer: "overflow-hidden rounded-xl bg-muted",
+} as const;
+
+
+const cn = (...classes: (string | undefined | false | null)[]) =>
+  classes.filter(Boolean).join(" ");
+
+const getTagColor = (tag: string): string =>
+  TAG_COLORS[tag as keyof typeof TAG_COLORS] ?? TAG_COLORS.default;
+
+
+const LocationIcon: React.FC<{ className?: string }> = ({ className = "h-4 w-4" }) => (
   <svg viewBox="0 0 24 24" aria-hidden className={className}>
     <path
       fill="currentColor"
@@ -35,69 +81,243 @@ const IconLocation = ({ className = "h-4 w-4" }: { className?: string }) => (
   </svg>
 );
 
-const IconStar = ({ className = "h-4 w-4" }: { className?: string }) => (
+const StarIcon: React.FC<{ className?: string }> = ({ className = "h-4 w-4" }) => (
   <svg viewBox="0 0 24 24" aria-hidden className={cn("fill-current", className)}>
     <path d="M12 3.75l2.72 5.51 6.08.88-4.4 4.29 1.04 6.07L12 17.77l-5.44 2.85 1.04-6.07-4.4-4.29 6.08-.88L12 3.75z" />
   </svg>
 );
 
-function Rating({ value = 0, size = "md" }: { value?: number; size?: "xs" | "sm" | "md" }) {
-  let starSize = "h-5 w-5";
-  if (size === "xs") starSize = "h-3 w-3";
-  if (size === "sm") starSize = "h-[14px] w-[14px]";
 
-  const stars = [];
-  for (let i = 0; i < 5; i++) {
-    if (i < Math.floor(value)) {
-      stars.push(1);
-    } else if (i === Math.floor(value) && value % 1 >= 0.5) {
-      stars.push(0.5);
-    } else {
-      stars.push(0);
-    }
+const StarRating: React.FC<{ value: number; size: keyof typeof RATING_SIZES }> = React.memo(
+  ({ value = 0, size = "md" }) => {
+    const starSize = RATING_SIZES[size];
+    //  useMemo ถูกเรียกเสมอ ไม่ขึ้นกับเงื่อนไข (และอยู่ในคอมโพเนนต์นี้เอง)
+    const stars = React.useMemo(() => {
+      const result: (1 | 0.5 | 0)[] = [];
+      for (let i = 0; i < 5; i++) {
+        if (i < Math.floor(value)) result.push(1);
+        else if (i === Math.floor(value) && value % 1 >= 0.5) result.push(0.5);
+        else result.push(0);
+      }
+      return result;
+    }, [value]);
+
+    return (
+      <div className="flex items-center gap-1 text-success">
+        {stars.map((star, i) => (
+          <div key={i} className={starSize}>
+            {star === 1 ? (
+              <StarIcon className={starSize} />
+            ) : star === 0.5 ? (
+              <div className="relative">
+                <StarIcon className={starSize} />
+                <div className="absolute inset-y-0 right-0 w-1/2 bg-white" />
+              </div>
+            ) : (
+              <div className="opacity-30">
+                <StarIcon className={starSize} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    );
   }
+);
+StarRating.displayName = "StarRating";
 
-  return (
-    <div className="flex items-center gap-1 text-success">
-      {stars.map((star, i) => (
-        <div key={i} className={starSize}>
-          {star === 1 ? (
-            <IconStar className={starSize} />
-          ) : star === 0.5 ? (
-            <div className="relative">
-              <IconStar className={starSize} />
-              <div className="absolute inset-y-0 right-0 w-1/2 bg-white" />
-            </div>
-          ) : (
-            <div className="opacity-30">
-              <IconStar className={starSize} />
-            </div>
-          )}
+const TagChip: React.FC<{ label: string }> = React.memo(({ label }) => {
+  const colorClass = getTagColor(label);
+  return <span className={cn(CARD_STYLES.tag, colorClass)}>{label}</span>;
+});
+TagChip.displayName = "TagChip";
+
+const CardHeader: React.FC<{
+  title: string;
+  hostName: string;
+  rating: number;
+  avatarUrl?: string;
+  coverUrl: string;
+  showAvatar: boolean;
+  titleSize: "lg" | "md";
+  avatarSize: "sm" | "md";
+  ratingSize: keyof typeof RATING_SIZES;
+}> = React.memo(
+  ({ title, hostName, rating, avatarUrl, coverUrl, showAvatar, titleSize, avatarSize, ratingSize }) => (
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex min-w-0 items-center gap-3">
+        {showAvatar && (
+          <Image
+            src={avatarUrl || coverUrl}
+            alt=""
+            className={CARD_STYLES.avatar[avatarSize]}
+            width={avatarSize === "sm" ? 36 : 40}
+            height={avatarSize === "sm" ? 36 : 40}
+          />
+        )}
+        <div className="min-w-0">
+          <h3 className={cn("truncate", CARD_STYLES.title[titleSize])}>{title}</h3>
+          <p className={cn("truncate", CARD_STYLES.subtitle)}>By {hostName}</p>
         </div>
-      ))}
+      </div>
+      <div className="shrink-0 translate-y-[2px]">
+        <StarRating value={rating} size={ratingSize} />
+      </div>
     </div>
-  );
-}
+  )
+);
+CardHeader.displayName = "CardHeader";
 
-function Tag({ label }: { label: string }) {
-  let color = "bg-muted text-muted-text ring-border";
-  
-  if (label === "Dog") color = "bg-green-bg text-success ring-success";
-  if (label === "Cat") color = "bg-pink-bg text-pink ring-pink";
-  if (label === "Bird") color = "bg-blue-bg text-blue ring-blue";
-  if (label === "Rabbit") color = "bg-orange-1 text-orange-4 ring-orange-4";
+const LocationInfo: React.FC<{ location: string }> = React.memo(({ location }) => (
+  <div className={CARD_STYLES.location}>
+    <LocationIcon />
+    <span className={CARD_STYLES.locationText}>{location}</span>
+  </div>
+));
+LocationInfo.displayName = "LocationInfo";
 
-  return (
-    <span className={cn(
-      "inline-flex h-8 items-center rounded-full px-3 text-[14px] font-medium ring-1 ring-inset whitespace-nowrap shrink-0",
-      color
-    )}>
-      {label}
-    </span>
-  );
-}
+const TagList: React.FC<{ tags: string[] }> = React.memo(({ tags }) => (
+  <div className={CARD_STYLES.tagContainer}>
+    {tags.map((tag) => (
+      <TagChip key={tag} label={tag} />
+    ))}
+  </div>
+));
+TagList.displayName = "TagList";
 
-export function PetSitterCard({
+const CoverImage: React.FC<{ src: string; alt: string; width: number; height: number; className?: string }> =
+  React.memo(({ src, alt, width, height, className }) => (
+    <div className={cn(CARD_STYLES.imageContainer, className)}>
+      <Image src={src} alt={alt} className={CARD_STYLES.image} width={width} height={height} />
+    </div>
+  ));
+CoverImage.displayName = "CoverImage";
+
+
+const LargeCoverLayout: React.FC<{
+  title: string;
+  hostName: string;
+  location: string;
+  rating: number;
+  tags: string[];
+  coverUrl: string;
+  avatarUrl?: string;
+  showAvatar: boolean;
+  className?: string;
+}> = React.memo((props) => (
+  <article tabIndex={0} className={cn(CARD_STYLES.base, "w-[335px] min-h-[320px] p-4", props.className)}>
+    <CoverImage src={props.coverUrl} alt="" width={303} height={160} className="h-[160px] w-full" />
+    <div className="mt-3 space-y-3">
+      <CardHeader
+        title={props.title}
+        hostName={props.hostName}
+        rating={props.rating}
+        avatarUrl={props.avatarUrl}
+        coverUrl={props.coverUrl}
+        showAvatar={props.showAvatar}
+        titleSize="md"
+        avatarSize="sm"
+        ratingSize="xs"
+      />
+      <LocationInfo location={props.location} />
+      <TagList tags={props.tags} />
+    </div>
+  </article>
+));
+LargeCoverLayout.displayName = "LargeCoverLayout";
+
+const LargeSideLayout: React.FC<{
+  title: string;
+  hostName: string;
+  location: string;
+  rating: number;
+  tags: string[];
+  coverUrl: string;
+  avatarUrl?: string;
+  showAvatar: boolean;
+  className?: string;
+}> = React.memo((props) => (
+  <article tabIndex={0} className={cn(CARD_STYLES.base, "grid grid-cols-[280px_1fr] gap-4 p-4", props.className)}>
+    <CoverImage src={props.coverUrl} alt="" width={280} height={200} className="h-[200px] w-[280px]" />
+    <div className="min-w-0 self-center space-y-3">
+      <CardHeader
+        title={props.title}
+        hostName={props.hostName}
+        rating={props.rating}
+        avatarUrl={props.avatarUrl}
+        coverUrl={props.coverUrl}
+        showAvatar={props.showAvatar}
+        titleSize="lg"
+        avatarSize="md"
+        ratingSize="md"
+      />
+      <LocationInfo location={props.location} />
+      <TagList tags={props.tags} />
+    </div>
+  </article>
+));
+LargeSideLayout.displayName = "LargeSideLayout";
+
+const SmallWideLayout: React.FC<{
+  title: string;
+  hostName: string;
+  rating: number;
+  tags: string[];
+  coverUrl: string;
+  className?: string;
+}> = React.memo((props) => (
+  <article tabIndex={0} className={cn(CARD_STYLES.base, "grid h-[138px] w-[471px] grid-cols-[144px_1fr] gap-4 p-4", props.className)}>
+    <CoverImage src={props.coverUrl} alt="" width={144} height={108} className="h-[108px] w-[144px]" />
+    <div className="min-w-0 grid grid-rows-[auto_auto_1fr] items-start">
+      <div className="min-w-0">
+        <h3 className={cn("truncate", CARD_STYLES.title.md)}>{props.title}</h3>
+        <p className={cn("truncate", CARD_STYLES.subtitle)}>By {props.hostName}</p>
+      </div>
+      <div className="mt-1">
+        <StarRating value={props.rating} size="sm" />
+      </div>
+      <div className="mt-2">
+        <TagList tags={props.tags} />
+      </div>
+    </div>
+  </article>
+));
+SmallWideLayout.displayName = "SmallWideLayout";
+
+const SmallCompactLayout: React.FC<{
+  title: string;
+  hostName: string;
+  rating: number;
+  tags: string[];
+  coverUrl: string;
+  className?: string;
+}> = React.memo((props) => (
+  <article
+    tabIndex={0}
+    className={cn(
+      CARD_STYLES.base,
+      "grid h-[146px] w-[330px] grid-cols-[97px_1fr] grid-rows-[auto_1fr] gap-x-4 gap-y-2 p-3",
+      props.className
+    )}
+  >
+    <CoverImage src={props.coverUrl} alt="" width={97} height={73} className="h-[73px] w-[97px]" />
+    <div className="min-w-0 self-start">
+      <h3 className={cn("truncate", CARD_STYLES.title.md)}>{props.title}</h3>
+      <p className={cn("truncate", CARD_STYLES.subtitle)}>By {props.hostName}</p>
+      <div className="mt-1">
+        <StarRating value={props.rating} size="sm" />
+      </div>
+    </div>
+    <div className="col-span-2 row-start-2 mt-1">
+      <TagList tags={props.tags} />
+    </div>
+  </article>
+));
+SmallCompactLayout.displayName = "SmallCompactLayout";
+
+
+// ไม่มีการเรียก Hook แบบมีเงื่อนไขในตัวหลัก
+const PetSitterCardBase: React.FC<PetSitterCardProps> = ({
   size = "lg",
   title,
   hostName,
@@ -110,146 +330,36 @@ export function PetSitterCard({
   className,
   smPreset = "wide",
   lgLayout = "side",
-}: PetSitterCardProps) {
+}) => {
   const isSmall = size === "sm";
-  const showAv = showAvatar !== undefined ? showAvatar : !isSmall;
+  const shouldShowAvatar = showAvatar !== undefined ? showAvatar : !isSmall;
 
-  if (!isSmall && lgLayout === "cover") {
-    return (
-      <article
-        tabIndex={0}
-        className={cn(
-          "group w-[335px] min-h-[268px] rounded-2xl border border-border bg-white p-4 cursor-pointer hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] focus-visible:outline-none",
-          className
-        )}
-      >
-        <div className="h-[100px] w-full overflow-hidden rounded-xl bg-muted">
-          <Image src={coverUrl} alt="" className="h-full w-full object-cover" width={303} height={100} />
-        </div>
-        <div className="mt-3 space-y-3">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex min-w-0 items-center gap-3">
-              {showAv && (
-                <Image src={avatarUrl || coverUrl} alt="" className="h-9 w-9 rounded-full object-cover" width={36} height={36} />
-              )}
-              <div className="min-w-0">
-                <h3 className="truncate text-[20px] leading-7 font-semibold text-ink">{title}</h3>
-                <p className="truncate text-[14px] leading-5 text-muted-text">By {hostName}</p>
-              </div>
-            </div>
-            <div className="shrink-0 translate-y-[2px]">
-              <Rating value={rating} size="xs" />
-            </div>
-          </div>
-          <div className="flex items-center gap-1 text-muted-text">
-            <IconLocation />
-            <span className="truncate text-[14px] leading-5">{location}</span>
-          </div>
-          <div className="flex flex-row flex-wrap items-center gap-2">
-            {tags.map((tag) => <Tag key={tag} label={tag} />)}
-          </div>
-        </div>
-      </article>
-    );
-  }
+  const commonProps = { title, hostName, rating, tags, coverUrl, className };
 
   if (!isSmall) {
-    return (
-      <article
-        tabIndex={0}
-        className={cn(
-          "group grid cursor-pointer grid-cols-[224px_1fr] gap-4 rounded-2xl border border-border bg-white p-4 hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] focus-visible:outline-none",
-          className
-        )}
-      >
-        <div className="h-36 w-56 overflow-hidden rounded-xl bg-muted">
-          <Image src={coverUrl} alt="" className="h-full w-full object-cover" width={224} height={144} />
-        </div>
-        <div className="min-w-0 self-center space-y-3">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex min-w-0 items-center gap-3">
-              {showAv && (
-                <Image src={avatarUrl || coverUrl} alt="" className="h-10 w-10 rounded-full object-cover" width={40} height={40} />
-              )}
-              <div className="min-w-0">
-                <h3 className="truncate text-[24px] leading-8 font-semibold text-ink">{title}</h3>
-                <p className="truncate text-[14px] leading-5 text-muted-text">By {hostName}</p>
-              </div>
-            </div>
-            <div className="shrink-0 translate-y-[2px]">
-              <Rating value={rating} size="md" />
-            </div>
-          </div>
-          <div className="flex items-center gap-1 text-muted-text">
-            <IconLocation />
-            <span className="truncate text-[14px] leading-5">{location}</span>
-          </div>
-          <div className="flex flex-row flex-wrap items-center gap-2">
-            {tags.map((tag) => <Tag key={tag} label={tag} />)}
-          </div>
-        </div>
-      </article>
+    const largeProps = {
+      ...commonProps,
+      location,
+      avatarUrl,
+      showAvatar: shouldShowAvatar,
+    };
+    return lgLayout === "cover" ? (
+      <LargeCoverLayout {...largeProps} />
+    ) : (
+      <LargeSideLayout {...largeProps} />
     );
   }
 
-  if (smPreset === "wide") {
-    return (
-      <article
-        tabIndex={0}
-        className={cn(
-          "group grid w-[471px] h-[138px] cursor-pointer grid-cols-[144px_1fr] gap-4 rounded-2xl border border-border bg-white p-4 hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] focus-visible:outline-none",
-          className
-        )}
-      >
-        <div className="h-[108px] w-[144px] overflow-hidden rounded-xl bg-muted">
-          <Image src={coverUrl} alt="" className="h-full w-full object-cover" width={144} height={108} />
-        </div>
-        <div className="min-w-0 grid grid-rows-[auto_auto_1fr] items-start">
-          <div className="min-w-0">
-            <h3 className="truncate text-[20px] leading-7 font-semibold text-ink">{title}</h3>
-            <p className="truncate text-[14px] leading-5 text-muted-text">By {hostName}</p>
-          </div>
-          <div className="mt-1">
-            <Rating value={rating} size="sm" />
-          </div>
-          <div className="mt-2 flex flex-row flex-wrap items-center gap-2">
-            {tags.map((tag) => <Tag key={tag} label={tag} />)}
-          </div>
-        </div>
-      </article>
-    );
-  }
-
-  return (
-    <article
-      tabIndex={0}
-      className={cn(
-        "group grid w-[330px] h-[146px] cursor-pointer grid-cols-[97px_1fr] grid-rows-[auto_1fr] gap-x-4 gap-y-2 rounded-2xl border border-border bg-white p-3 hover:shadow-[0_6px_24px_rgba(50,54,64,0.08)] focus-visible:outline-none",
-        className
-      )}
-    >
-      <div className="h-[73px] w-[97px] overflow-hidden rounded-xl bg-muted">
-        <Image src={coverUrl} alt="" className="h-full w-full object-cover" width={97} height={73} />
-      </div>
-      <div className="min-w-0 self-start">
-        <h3 className="truncate text-[20px] leading-7 font-semibold text-ink">{title}</h3>
-        <p className="truncate text-[14px] leading-5 text-muted-text">By {hostName}</p>
-        <div className="mt-1">
-          <Rating value={rating} size="sm" />
-        </div>
-      </div>
-      <div className="col-span-2 row-start-2 mt-1 flex flex-row flex-wrap items-center gap-2">
-        {tags.map((tag) => <Tag key={tag} label={tag} />)}
-      </div>
-    </article>
+  return smPreset === "wide" ? (
+    <SmallWideLayout {...commonProps} />
+  ) : (
+    <SmallCompactLayout {...commonProps} />
   );
-}
+};
 
-export const PetSitterCardLarge = (props: Omit<PetSitterCardProps, "size">) => (
-  <PetSitterCard size="lg" {...props} />
-);
-export const PetSitterCardSmall = (props: Omit<PetSitterCardProps, "size">) => (
-  <PetSitterCard size="sm" {...props} />
-);
+//  เมโมคอมโพเนนต์หลัก เพื่อลด re-render เมื่อพร็อพเหมือนเดิม
+export const PetSitterCard = React.memo(PetSitterCardBase);
+export const PetSitterCardLarge = (props: Omit<PetSitterCardProps, "size">) => <PetSitterCard size="lg" {...props} />;
+export const PetSitterCardSmall = (props: Omit<PetSitterCardProps, "size">) => <PetSitterCard size="sm" {...props} />;
 
 export default PetSitterCard;

--- a/src/components/cards/index.ts
+++ b/src/components/cards/index.ts
@@ -1,1 +1,0 @@
-export * from "./PetSitterCard";

--- a/src/components/features/account/AccountTabs.tsx
+++ b/src/components/features/account/AccountTabs.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import * as React from "react";
+import { useMemo, useCallback } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+/* ---- Types ---- */
+type IconProps = { active?: boolean };
+
+type TabConfig = { 
+  href: string; 
+  label: string; 
+  icon: (active: boolean) => React.ReactElement;
+  value: string;
+};
+
+type Props = {
+  className?: string;
+};
+
+/* ---- Constants ---- */
+const OPACITY = {
+  ACTIVE: 1,
+  INACTIVE: 0.45,
+} as const;
+
+const ICON_SIZE = {
+  WIDTH: 24,
+  HEIGHT: 24,
+} as const;
+
+const SVG_STYLES = { display: "block" } as const;
+
+/* ---- Icon Components ---- */
+const ProfileIcon: React.FC<IconProps> = React.memo(({ active }) => {
+  const opacity = active ? OPACITY.ACTIVE : OPACITY.INACTIVE;
+  
+  return (
+    <svg width={ICON_SIZE.WIDTH} height={ICON_SIZE.HEIGHT} viewBox="0 0 24 24" style={SVG_STYLES}>
+      <circle 
+        cx={12} 
+        cy={8} 
+        r={3.25} 
+        fill="none" 
+        stroke="currentColor" 
+        strokeWidth={1.8} 
+        opacity={opacity} 
+      />
+      <path 
+        d="M4.8 19c1.8-3 12.6-3 14.4 0" 
+        fill="none" 
+        stroke="currentColor" 
+        strokeWidth={1.8} 
+        opacity={opacity} 
+        strokeLinecap="round" 
+      />
+    </svg>
+  );
+});
+ProfileIcon.displayName = "ProfileIcon";
+
+const PawIcon: React.FC<IconProps> = React.memo(({ active }) => {
+  const opacity = active ? OPACITY.ACTIVE : OPACITY.INACTIVE;
+  
+  return (
+    <svg width={ICON_SIZE.WIDTH} height={ICON_SIZE.HEIGHT} viewBox="0 0 24 24" style={SVG_STYLES}>
+      <circle cx={7.5} cy={8.5} r={2} fill="currentColor" opacity={opacity} />
+      <circle cx={12} cy={6.5} r={2} fill="currentColor" opacity={opacity} />
+      <circle cx={16.5} cy={8.5} r={2} fill="currentColor" opacity={opacity} />
+      <path 
+        d="M8 15.5c0-1.9 1.6-3.5 4-3.5s4 1.6 4 3.5c0 2.1-1.8 3.3-4 3.3s-4-1.2-4-3.3z" 
+        fill="currentColor" 
+        opacity={opacity} 
+      />
+    </svg>
+  );
+});
+PawIcon.displayName = "PawIcon";
+
+const ListIcon: React.FC<IconProps> = React.memo(({ active }) => {
+  const opacity = active ? OPACITY.ACTIVE : OPACITY.INACTIVE;
+  
+  return (
+    <svg width={ICON_SIZE.WIDTH} height={ICON_SIZE.HEIGHT} viewBox="0 0 24 24" style={SVG_STYLES}>
+      <rect x={6} y={6.5} width={12} height={1.8} rx={0.9} fill="currentColor" opacity={opacity} />
+      <rect x={6} y={11.1} width={12} height={1.8} rx={0.9} fill="currentColor" opacity={opacity} />
+      <rect x={6} y={15.7} width={12} height={1.8} rx={0.9} fill="currentColor" opacity={opacity} />
+      <circle cx={4.2} cy={7.4} r={0.9} fill="currentColor" opacity={opacity} />
+      <circle cx={4.2} cy={12} r={0.9} fill="currentColor" opacity={opacity} />
+      <circle cx={4.2} cy={16.6} r={0.9} fill="currentColor" opacity={opacity} />
+    </svg>
+  );
+});
+ListIcon.displayName = "ListIcon";
+
+/* ---- Tab Configuration ---- */
+const TAB_CONFIGS: readonly TabConfig[] = [
+  { 
+    href: "/account/profile", 
+    label: "Profile", 
+    value: "profile", 
+    icon: (active) => <ProfileIcon active={active} /> 
+  },
+  { 
+    href: "/account/pet", 
+    label: "Your Pet", 
+    value: "pet", 
+    icon: (active) => <PawIcon active={active} /> 
+  },
+  { 
+    href: "/account/bookings", 
+    label: "Booking History", 
+    value: "bookings", 
+    icon: (active) => <ListIcon active={active} /> 
+  },
+] as const;
+
+/* ---- Styles ---- */
+const STYLES = {
+  container: "w-full md:hidden",
+  tabsList: `
+    w-full h-14 p-0 bg-[var(--surface)] 
+    border-b border-slate-200/20 rounded-none 
+    justify-start overflow-x-auto
+  `,
+  tabTrigger: {
+    base: `
+      flex-shrink-0 h-full flex items-center justify-start gap-2.5
+      text-base font-bold whitespace-nowrap rounded-none
+      transition-colors duration-200
+      hover:bg-transparent
+      focus-visible:ring-0 focus-visible:ring-offset-0
+    `,
+    active: `
+      data-[state=active]:bg-orange-100 
+      data-[state=active]:text-orange-600
+      data-[state=active]:shadow-none
+    `,
+    inactive: "data-[state=inactive]:text-slate-500"
+  }
+} as const;
+
+/* ---- Utility Functions ---- */
+const findCurrentTab = (pathname: string): string => {
+  const matchedTab = TAB_CONFIGS.find((tab) => pathname.startsWith(tab.href));
+  return matchedTab ? matchedTab.value : TAB_CONFIGS[0].value;
+};
+
+const getTabPadding = (index: number): string => {
+  return index === 0 ? 'pl-0 pr-6' : 'px-6';
+};
+
+const combineTabStyles = (index: number): string => {
+  return [
+    STYLES.tabTrigger.base,
+    STYLES.tabTrigger.active,
+    STYLES.tabTrigger.inactive,
+    getTabPadding(index)
+  ].join(' ');
+};
+
+/* ---- Main Component ---- */
+export default function AccountTabsShadcn({ className = "" }: Props) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentValue = useMemo(
+    () => findCurrentTab(pathname ?? ""), 
+    [pathname]
+  );
+
+  const handleValueChange = useCallback((value: string) => {
+    const selectedTab = TAB_CONFIGS.find(tab => tab.value === value);
+    if (selectedTab) {
+      router.push(selectedTab.href);
+    }
+  }, [router]);
+
+  const containerClassName = `${STYLES.container} ${className}`;
+
+  return (
+    <div className={containerClassName}>
+      <Tabs 
+        value={currentValue} 
+        onValueChange={handleValueChange}
+        className="w-full"
+      >
+        <TabsList className={STYLES.tabsList}>
+          {TAB_CONFIGS.map((tab, index) => {
+            const isActive = currentValue === tab.value;
+            
+            return (
+              <TabsTrigger
+                key={tab.href}
+                value={tab.value}
+                className={combineTabStyles(index)}
+              >
+                {tab.icon(isActive)}
+                <span>{tab.label}</span>
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/features/account/ProfileForm.tsx
+++ b/src/components/features/account/ProfileForm.tsx
@@ -1,187 +1,270 @@
-import React from "react";
-import { Control, Controller } from "react-hook-form";
+import * as React from "react";
+import {
+  Control,
+  Controller,
+  ControllerRenderProps,
+  ControllerFieldState,
+  Path,
+} from "react-hook-form";
+import type { OwnerProfileInput } from "@/lib/validators/account";
 import InputText from "@/components/input/InputText";
 import AvatarUploader from "@/components/form/AvatarUpload";
 import PrimaryButton from "@/components/buttons/PrimaryButton";
 import { cn } from "@/lib/utils";
 
-export type OwnerProfileValues = {
-  name: string;
-  email: string;
-  phone: string;
-  idNumber?: string;
-  dob?: string;          // YYYY-MM-DD
-  profileImage?: string; // URL/base64
-};
-
-type Props = {
-  control: Control<OwnerProfileValues>;
+/* ---- Types ---- */
+export interface ProfileFormProps {
+  control: Control<OwnerProfileInput>;
   onSubmit: () => void;
   saving?: boolean;
   serverError?: string | null;
+}
+
+type FormFieldProps<Name extends Path<OwnerProfileInput>> = {
+  control: Control<OwnerProfileInput>;
+  name: Name;
+  children: (
+    field: ControllerRenderProps<OwnerProfileInput, Name>,
+    fieldState: ControllerFieldState
+  ) => React.ReactElement;
 };
 
+type FieldConfig = {
+  id: string;
+  label: string;
+  placeholder?: string;
+  type: string;
+  autoComplete?: string;
+  inputMode?:
+    | "text"
+    | "email"
+    | "tel"
+    | "numeric"
+    | "search"
+    | "none"
+    | "url"
+    | "decimal";
+  pattern?: string;
+  maxLength?: number;
+};
+
+/* ---- Constants ---- */
+const FORM_CONFIG = {
+  fields: {
+    name: {
+      id: "name",
+      label: "Your Name*",
+      placeholder: "John Wick",
+      type: "text",
+      autoComplete: "name",
+    },
+    email: {
+      id: "email",
+      label: "Email*",
+      placeholder: "johnwick@dogorg.com",
+      type: "email",
+      autoComplete: "email",
+    },
+    phone: {
+      id: "phone",
+      label: "Phone*",
+      placeholder: "099 996 6734",
+      type: "tel",
+      inputMode: "tel",
+      pattern: "^0\\d{9}$",
+      autoComplete: "tel",
+    },
+    idNumber: {
+      id: "idNumber",
+      label: "ID Number",
+      placeholder: "13 digits",
+      type: "text",
+      inputMode: "numeric",
+      pattern: "^\\d{13}$",
+      maxLength: 13,
+    },
+    dob: {
+      id: "dob",
+      label: "Date of Birth",
+      type: "date",
+      placeholder: "YYYY-MM-DD",
+    },
+  } as const,
+  styles: {
+    form: "text-ink space-y-6",
+    error:
+      "rounded-md border border-red-300 bg-red-50 px-4 py-3 text-red-700",
+    avatarContainer: "w-fit",
+    avatarHelp: "mt-2 text-xs text-muted-foreground",
+    grid: "grid gap-4 md:grid-cols-2",
+    buttonContainer: "flex justify-end",
+    hiddenSubmit: "sr-only",
+  },
+};
+
+/* ---- Helpers ---- */
+const getTodayString = (): string => new Date().toISOString().slice(0, 10);
+const formatIdNumber = (v: string): string => v.replace(/\D/g, "").slice(0, 13);
+type InputVariant = "default" | "error" | "success";
+const getInputVariant = (hasError: boolean): InputVariant =>
+  hasError ? "error" : "default";
+
+/* ---- Reusable ---- */
+function FormField<Name extends Path<OwnerProfileInput>>(
+  props: FormFieldProps<Name>
+) {
+  const { control, name, children } = props;
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => children(field, fieldState)}
+    />
+  );
+}
+
+const ErrorMessage: React.FC<{ message: string }> = ({ message }) => (
+  <div className={FORM_CONFIG.styles.error}>{message}</div>
+);
+
+/* ---- Fields ---- */
+const AvatarField: React.FC<{ control: Control<OwnerProfileInput> }> = ({
+  control,
+}) => (
+  <FormField control={control} name={"image"}>
+    {(field) => {
+      const value = typeof field.value === "string" ? field.value : "";
+      return (
+        <div className={FORM_CONFIG.styles.avatarContainer}>
+          <AvatarUploader imageUrl={value} onChange={field.onChange} />
+          <p className={FORM_CONFIG.styles.avatarHelp}>
+            Profile Image (optional)
+          </p>
+        </div>
+      );
+    }}
+  </FormField>
+);
+
+const TextInputField: React.FC<{
+  control: Control<OwnerProfileInput>;
+  name: Path<OwnerProfileInput>;
+  config: FieldConfig;
+  customProps?: Partial<React.ComponentProps<typeof InputText>>;
+}> = ({ control, name, config, customProps }) => (
+  <FormField control={control} name={name}>
+    {(field, fieldState) => (
+      <InputText
+        {...config}
+        name={name}
+        placeholder={config.placeholder ?? ""}
+        value={(field.value as string | undefined) ?? ""}
+        onChange={field.onChange}
+        onBlur={field.onBlur}
+        variant={getInputVariant(!!fieldState.error)}
+        errorText={fieldState.error?.message ?? ""}
+        aria-invalid={!!fieldState.error}
+        {...customProps}
+      />
+    )}
+  </FormField>
+);
+
+const IdNumberField: React.FC<{ control: Control<OwnerProfileInput> }> = ({
+  control,
+}) => (
+  <FormField control={control} name={"idNumber"}>
+    {(field, fieldState) => (
+      <InputText
+        {...FORM_CONFIG.fields.idNumber}
+        name="idNumber"
+        placeholder={FORM_CONFIG.fields.idNumber.placeholder ?? ""}
+        value={(field.value as string | undefined) ?? ""}
+        onChange={(e) => field.onChange(formatIdNumber(e.currentTarget.value))}
+        onBlur={field.onBlur}
+        variant={getInputVariant(!!fieldState.error)}
+        errorText={fieldState.error?.message ?? ""}
+        aria-invalid={!!fieldState.error}
+      />
+    )}
+  </FormField>
+);
+
+const DateField: React.FC<{ control: Control<OwnerProfileInput> }> = ({
+  control,
+}) => {
+  const today = React.useMemo(() => getTodayString(), []);
+  return (
+    <FormField control={control} name={"dob"}>
+      {(field, fieldState) => (
+        <InputText
+          {...FORM_CONFIG.fields.dob}
+          name="dob"
+          placeholder={FORM_CONFIG.fields.dob.placeholder ?? ""}
+          value={(field.value as string | undefined) ?? ""}
+          onChange={field.onChange}
+          onBlur={field.onBlur}
+          max={today}
+          variant={getInputVariant(!!fieldState.error)}
+          errorText={fieldState.error?.message ?? ""}
+          aria-invalid={!!fieldState.error}
+          onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
+        />
+      )}
+    </FormField>
+  );
+};
+
+/* ---- Main ---- */
 export default function ProfileForm({
   control,
   onSubmit,
   saving = false,
   serverError,
-}: Props) {
+}: ProfileFormProps) {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!saving) onSubmit();
+  };
+
+  const submitButtonProps = {
+    text: saving ? "Saving..." : "Update Profile",
+    bgColor: "primary",
+    textColor: "white",
+    className: cn(
+      "px-6 rounded-full transition hover:opacity-95 focus:outline-none",
+      saving && "opacity-50 pointer-events-none"
+    ),
+    onClick: () => {
+      if (!saving) onSubmit();
+    },
+  } satisfies React.ComponentProps<typeof PrimaryButton>;
+
   return (
     <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (!saving) onSubmit();
-      }}
-
-      className="text-ink space-y-6"
+      onSubmit={handleSubmit}
+      className={FORM_CONFIG.styles.form}
       aria-label="Owner profile form"
     >
+      {serverError && <ErrorMessage message={serverError} />}
 
-      <div>
-        <Controller
-          control={control}
-          name="profileImage"
-          render={({ field }) => (
+      <AvatarField control={control} />
 
-            <div className="w-fit">
-              <AvatarUploader imageUrl={typeof field.value === "string" ? field.value : ""} />
-              <p className="mt-2 text-xs text-muted-foreground">Profile Image (optional)</p>
-            </div>
-          )}
-        />
+      <TextInputField control={control} name={"name"} config={FORM_CONFIG.fields.name} />
+
+      <div className={FORM_CONFIG.styles.grid}>
+        <TextInputField control={control} name={"email"} config={FORM_CONFIG.fields.email} />
+        <TextInputField control={control} name={"phone"} config={FORM_CONFIG.fields.phone} />
       </div>
 
-      {/* Name */}
-      <div>
-        <Controller
-          control={control}
-          name="name"
-          render={({ field, fieldState }) => (
-            <div>
-              <InputText
-                label="Your Name*"
-                placeholder="John Wick"
-                type="text"
-                value={field.value}
-                onChange={field.onChange}
-                variant={fieldState.error ? "error" : "default"}
-                aria-invalid={!!fieldState.error}
-              />
-              {fieldState.error && (
-                <p className="mt-1 text-xs text-destructive">{fieldState.error.message}</p>
-              )}
-            </div>
-          )}
-        />
+      <div className={FORM_CONFIG.styles.grid}>
+        <IdNumberField control={control} />
+        <DateField control={control} />
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <Controller
-          control={control}
-          name="email"
-          render={({ field, fieldState }) => (
-            <div>
-              <InputText
-                label="Email*"
-                placeholder="johnwick@dogorg.com"
-                type="email"
-                value={field.value}
-                onChange={field.onChange}
-                variant={fieldState.error ? "error" : "default"}
-                aria-invalid={!!fieldState.error}
-              />
-              {fieldState.error && (
-                <p className="mt-1 text-xs text-destructive">{fieldState.error.message}</p>
-              )}
-            </div>
-          )}
-        />
-        <Controller
-          control={control}
-          name="phone"
-          render={({ field, fieldState }) => (
-            <div>
-              <InputText
-                label="Phone*"
-                placeholder="099 996 6734"
-                type="tel"
-                value={field.value}
-                onChange={field.onChange}
-                variant={fieldState.error ? "error" : "default"}
-                aria-invalid={!!fieldState.error}
-              />
-              {fieldState.error && (
-                <p className="mt-1 text-xs text-destructive">{fieldState.error.message}</p>
-              )}
-            </div>
-          )}
-        />
-      </div>
-
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <Controller
-          control={control}
-          name="idNumber"
-          render={({ field, fieldState }) => (
-            <div>
-              <InputText
-                label="ID Number"
-                placeholder="13 digits"
-                type="text"
-                value={field.value ?? ""}
-                onChange={field.onChange}
-                variant={fieldState.error ? "error" : "default"}
-                aria-invalid={!!fieldState.error}
-              />
-              {fieldState.error && (
-                <p className="mt-1 text-xs text-destructive">{fieldState.error.message}</p>
-              )}
-            </div>
-          )}
-        />
-        <Controller
-          control={control}
-          name="dob"
-          render={({ field, fieldState }) => (
-            <div>
-              <InputText
-                label="Date of Birth"
-                type="date"
-                value={field.value || ""} // YYYY-MM-DD
-                placeholder="YYYY-MM-DD"
-                onChange={field.onChange}
-                variant={fieldState.error ? "error" : "default"}
-                aria-invalid={!!fieldState.error}
-              />
-              {fieldState.error && (
-                <p className="mt-1 text-xs text-destructive">{fieldState.error.message}</p>
-              )}
-            </div>
-          )}
-        />
-      </div>
-
- 
-      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
-
-
-      <div className="flex justify-end">
-        <PrimaryButton
-          text={saving ? "Saving..." : "Update Profile"}
-          bgColor="primary"
-          textColor="white"
-          className={cn(
-            "px-6 transition hover:opacity-95 focus:outline-none",
-            saving && "opacity-50 pointer-events-none"
-          )}
-          onClick={() => {
-            if (!saving) onSubmit();
-          }}
-        />
-
-        <button type="submit" className="sr-only" aria-hidden />
+      <div className={FORM_CONFIG.styles.buttonContainer}>
+        <PrimaryButton {...submitButtonProps} />
+        <button type="submit" className={FORM_CONFIG.styles.hiddenSubmit} aria-hidden />
       </div>
     </form>
   );

--- a/src/components/features/pet/PetForm.tsx
+++ b/src/components/features/pet/PetForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Image from "next/image";
 
+
 export type PetFormValues = {
   name: string;
   type: string;
@@ -10,7 +11,7 @@ export type PetFormValues = {
   color: string;
   weightKg: string;
   about: string;
-  image: string; // เก็บเป็น URL / data URL
+  image: string;
 };
 
 type PetFormProps = {
@@ -20,10 +21,25 @@ type PetFormProps = {
   serverError?: string | null;
   onSubmit: (values: PetFormValues) => void;
   onCancel: () => void;
-  onDelete?: () => void; // โชว์ปุ่มลบเมื่อมี
+  onDelete?: () => void;
 };
 
-const emptyValues: PetFormValues = {
+type FormFieldConfig = {
+  name: keyof PetFormValues;
+  label: string;
+  placeholder: string;
+  type?: string;
+  inputMode?: "text" | "numeric" | "decimal";
+  required?: boolean;
+};
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+
+const EMPTY_VALUES: PetFormValues = {
   name: "",
   type: "",
   breed: "",
@@ -35,6 +51,236 @@ const emptyValues: PetFormValues = {
   image: "",
 };
 
+const FORM_FIELDS: FormFieldConfig[] = [
+  {
+    name: "name",
+    label: "Pet Name*",
+    placeholder: "Your pet name",
+    required: true
+  },
+  {
+    name: "breed", 
+    label: "Breed*",
+    placeholder: "Breed of your pet",
+    required: true
+  },
+  {
+    name: "ageMonth",
+    label: "Age (Month)*", 
+    placeholder: "e.g., 6",
+    inputMode: "numeric",
+    required: true
+  },
+  {
+    name: "color",
+    label: "Color*",
+    placeholder: "Describe color of your pet", 
+    required: true
+  },
+  {
+    name: "weightKg",
+    label: "Weight (Kilogram)*",
+    placeholder: "e.g., 3.5",
+    inputMode: "decimal",
+    required: true
+  }
+];
+
+const PET_TYPE_OPTIONS: SelectOption[] = [
+  { value: "", label: "Select your pet type" },
+  { value: "Dog", label: "Dog" },
+  { value: "Cat", label: "Cat" },
+  { value: "Bird", label: "Bird" },
+  { value: "Rabbit", label: "Rabbit" },
+  { value: "Other", label: "Other" }
+];
+
+const SEX_OPTIONS: SelectOption[] = [
+  { value: "", label: "Select sex of your pet" },
+  { value: "Male", label: "Male" },
+  { value: "Female", label: "Female" }
+];
+
+const STYLES = {
+  form: "space-y-6",
+  error: "rounded-lg bg-pink/10 p-3 text-[14px] text-pink ring-1 ring-pink/30",
+  grid: {
+    main: "grid gap-6 md:grid-cols-[220px,1fr]",
+    fields: "grid gap-4 md:grid-cols-2",
+    buttons: {
+      mobile: "mt-3 grid grid-cols-2 gap-3 md:hidden",
+      desktop: "mt-3 hidden md:grid grid-cols-2 gap-3"
+    }
+  },
+  image: {
+    container: "space-y-3",
+    preview: "h-40 w-40 overflow-hidden rounded-xl bg-slate-100 ring-1 ring-border flex items-center justify-center",
+    upload: "inline-flex cursor-pointer items-center justify-center rounded-full border border-border px-3 py-2 text-[13px] font-medium text-ink hover:bg-muted/40 transition"
+  },
+  input: {
+    base: "mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg",
+    textarea: "mt-1 w-full rounded-md border border-border bg-white p-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
+  },
+  button: {
+    cancel: "h-11 rounded-full bg-orange-1/40 text-orange-6 font-semibold hover:bg-orange-1/60 transition cursor-pointer disabled:cursor-not-allowed",
+    submit: "h-11 rounded-full bg-brand text-white font-bold hover:brightness-95 hover:shadow disabled:opacity-50 transition cursor-pointer disabled:cursor-not-allowed",
+    delete: "inline-flex items-center gap-2 text-orange-600 font-semibold hover:text-orange-700 cursor-pointer"
+  },
+  label: "text-[14px] font-medium text-muted-text"
+};
+
+
+const handleFileToDataURL = (file: File): Promise<string> => {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result);
+    };
+    reader.readAsDataURL(file);
+  });
+};
+
+
+const ErrorMessage: React.FC<{ message: string }> = ({ message }) => (
+  <div className={STYLES.error}>
+    {message}
+  </div>
+);
+
+const FormLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <label className={STYLES.label}>{children}</label>
+);
+
+const FormInput: React.FC<{
+  config: FormFieldConfig;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}> = ({ config, value, onChange }) => (
+  <div>
+    <FormLabel>{config.label}</FormLabel>
+    <input
+      name={config.name}
+      value={value}
+      onChange={onChange}
+      placeholder={config.placeholder}
+      inputMode={config.inputMode}
+      className={STYLES.input.base}
+    />
+  </div>
+);
+
+const FormSelect: React.FC<{
+  name: string;
+  label: string;
+  value: string;
+  options: SelectOption[];
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}> = ({ name, label, value, options, onChange }) => (
+  <div>
+    <FormLabel>{label}</FormLabel>
+    <select
+      name={name}
+      value={value}
+      onChange={onChange}
+      className={STYLES.input.base}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+const ImageUpload: React.FC<{
+  preview: string;
+  onImageChange: (file?: File) => Promise<void>;
+}> = ({ preview, onImageChange }) => {
+  const hasImage = preview.trim().length > 0;
+
+  return (
+    <div className={STYLES.image.container}>
+      <FormLabel>Pet Image</FormLabel>
+      
+      <div className={STYLES.image.preview}>
+        {hasImage ? (
+          <Image
+            src={preview}
+            alt="Pet image"
+            width={160}
+            height={160}
+            className="object-cover"
+          />
+        ) : (
+          <span className="text-slate-400 text-sm">No image</span>
+        )}
+      </div>
+
+      <label className={STYLES.image.upload}>
+        <input
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => onImageChange(e.target.files?.[0])}
+        />
+        Upload Image
+      </label>
+    </div>
+  );
+};
+
+const DeleteButton: React.FC<{ onDelete: () => void }> = ({ onDelete }) => (
+  <div className="mt-2 flex justify-center md:justify-start">
+    <button
+      type="button"
+      onClick={onDelete}
+      className={STYLES.button.delete}
+    >
+      <svg aria-hidden="true" className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M9 3h6a1 1 0 0 1 1 1v1h4v2H4V5h4V4a1 1 0 0 1 1-1Zm2 4h2v12h-2V7ZM7 7h2v12H7V7Zm8 0h2v12h-2V7Z" />
+      </svg>
+      Delete Pet
+    </button>
+  </div>
+);
+
+const ActionButtons: React.FC<{
+  mode: "create" | "edit";
+  loading: boolean;
+  onCancel: () => void;
+  isMobile?: boolean;
+}> = ({ mode, loading, onCancel, isMobile = false }) => {
+  const submitLabel = mode === "edit" ? "Update Pet" : "Create Pet";
+  const loadingLabel = loading ? "Saving..." : submitLabel;
+  
+  const gridClass = isMobile ? STYLES.grid.buttons.mobile : STYLES.grid.buttons.desktop;
+  const buttonSpacing = isMobile ? "" : "px-6";
+  const cancelClass = isMobile ? "" : "justify-self-start";
+  const submitClass = isMobile ? "" : "justify-self-end";
+
+  return (
+    <div className={gridClass}>
+      <button
+        type="button"
+        onClick={onCancel}
+        className={`${STYLES.button.cancel} ${buttonSpacing} ${cancelClass}`}
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        disabled={loading}
+        className={`${STYLES.button.submit} ${buttonSpacing} ${submitClass}`}
+      >
+        {loadingLabel}
+      </button>
+    </div>
+  );
+};
+
+
 export default function PetForm({
   mode,
   initialValues,
@@ -45,203 +291,117 @@ export default function PetForm({
   onDelete,
 }: PetFormProps) {
   const [values, setValues] = React.useState<PetFormValues>({
-    ...emptyValues,
+    ...EMPTY_VALUES,
     ...initialValues,
   });
 
-  const [preview, setPreview] = React.useState<string>(initialValues?.image ?? "");
+  const [preview, setPreview] = React.useState<string>(
+    (initialValues?.image ?? "").trim()
+  );
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+
+  React.useEffect(() => {
+    if (!initialValues) return;
+    setValues((prev) => ({ ...prev, ...initialValues }));
+    setPreview((initialValues.image ?? "").trim());
+  }, [initialValues]);
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
     const { name, value } = e.target;
-    setValues((v) => ({ ...v, [name]: value }));
+    setValues((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleImageFile = async (file?: File) => {
+  const handleImageChange = async (file?: File) => {
     if (!file) {
-      setValues((v) => ({ ...v, image: "" }));
+      setValues((prev) => ({ ...prev, image: "" }));
       setPreview("");
       return;
     }
-
-    const reader = new FileReader();
-    reader.onload = () => {
-      const url = typeof reader.result === "string" ? reader.result : "";
-      setPreview(url);
-      setValues((v) => ({ ...v, image: url }));
-    };
-    reader.readAsDataURL(file);
+    
+    const dataURL = await handleFileToDataURL(file);
+    setPreview(dataURL);
+    setValues((prev) => ({ ...prev, image: dataURL }));
   };
 
-  const submitForm = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onSubmit(values);
   };
 
+  const isEdit = mode === "edit";
+  const showDelete = onDelete && isEdit;
+
   return (
-    <form onSubmit={submitForm} className="space-y-6">
+    <form onSubmit={handleSubmit} className={STYLES.form}>
 
-      <div className="flex items-center justify-between">
-        <h2 className="text-[18px] font-bold text-ink">{mode === "edit" ? "Edit Pet" : "Create Pet"}</h2>
-        <div className="flex items-center gap-2">
-          {onDelete && mode === "edit" && (
-            <button
-              type="button"
-              onClick={onDelete}
-              className="h-10 rounded-full bg-orange-1/40 px-4 text-[14px] font-medium text-orange-6 hover:bg-orange-1/60 transition"
-            >
-              Delete
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={onCancel}
-            className="h-10 rounded-full border border-border bg-white px-4 text-[14px] font-medium text-ink hover:bg-muted/40 transition"
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={loading}
-            className="h-10 rounded-full bg-brand px-5 text-[14px] font-bold text-white hover:brightness-95 hover:shadow disabled:opacity-50 transition"
-          >
-            {loading ? "Saving..." : mode === "edit" ? "Save Changes" : "Create"}
-          </button>
-        </div>
-      </div>
+      {serverError && <ErrorMessage message={serverError} />}
 
-      {serverError && (
-        <div className="rounded-lg bg-pink/10 p-3 text-[14px] text-pink ring-1 ring-pink/30">{serverError}</div>
-      )}
-
-
-      <div className="grid gap-6 md:grid-cols-[220px,1fr]">
-
-        <div className="space-y-3">
-          <div className="text-[14px] font-medium text-muted-text">Pet Image</div>
-
-
-          <div className="relative h-24 w-24 overflow-hidden rounded-md bg-muted ring-1 ring-border">
-            {preview ? (
-              <Image src={preview} alt="Pet preview" fill sizes="96px" className="object-cover" />
-            ) : (
-              <div className="grid h-full w-full place-items-center text-[12px] text-muted-text">No image</div>
-            )}
-          </div>
-
-          <label className="inline-flex cursor-pointer items-center justify-center rounded-full border border-border px-3 py-2 text-[13px] font-medium text-ink hover:bg-muted/40 transition">
-            <input
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={(e) => handleImageFile(e.target.files?.[0])}
-            />
-            Upload Image
-          </label>
-        </div>
+      <div className={STYLES.grid.main}>
+        <ImageUpload preview={preview} onImageChange={handleImageChange} />
 
 
         <div className="grid gap-4">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Name</label>
-              <input
-                name="name"
-                value={values.name}
-                onChange={handleChange}
-                placeholder="Your pet name"
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
+          <div className={STYLES.grid.fields}>
+
+            {FORM_FIELDS.map((config) => (
+              <FormInput
+                key={config.name}
+                config={config}
+                value={values[config.name]}
+                onChange={handleInputChange}
               />
-            </div>
+            ))}
 
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Type</label>
-              <select
-                name="type"
-                value={values.type}
-                onChange={handleChange}
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              >
-                <option value="">Select type</option>
-                <option value="Dog">Dog</option>
-                <option value="Cat">Cat</option>
-                <option value="Bird">Bird</option>
-                <option value="Rabbit">Rabbit</option>
-                <option value="Other">Other</option>
-              </select>
-            </div>
 
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Breed</label>
-              <input
-                name="breed"
-                value={values.breed}
-                onChange={handleChange}
-                placeholder="e.g., Pomeranian"
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              />
-            </div>
+            <FormSelect
+              name="type"
+              label="Pet Type*"
+              value={values.type}
+              options={PET_TYPE_OPTIONS}
+              onChange={handleInputChange}
+            />
 
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Sex</label>
-              <select
-                name="sex"
-                value={values.sex}
-                onChange={handleChange}
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              >
-                <option value="">Select sex</option>
-                <option value="Male">Male</option>
-                <option value="Female">Female</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Age (months)</label>
-              <input
-                name="ageMonth"
-                value={values.ageMonth}
-                onChange={handleChange}
-                placeholder="e.g., 6"
-                inputMode="numeric"
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              />
-            </div>
-
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Color</label>
-              <input
-                name="color"
-                value={values.color}
-                onChange={handleChange}
-                placeholder="e.g., Brown"
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              />
-            </div>
-
-            <div>
-              <label className="text-[14px] font-medium text-muted-text">Weight (kg)</label>
-              <input
-                name="weightKg"
-                value={values.weightKg}
-                onChange={handleChange}
-                placeholder="e.g., 3.5"
-                inputMode="decimal"
-                className="mt-1 h-10 w-full rounded-md border border-border bg-white px-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
-              />
-            </div>
+  
+            <FormSelect
+              name="sex"
+              label="Sex*"
+              value={values.sex}
+              options={SEX_OPTIONS}
+              onChange={handleInputChange}
+            />
           </div>
 
+     
           <div>
-            <label className="text-[14px] font-medium text-muted-text">About</label>
+            <FormLabel>About</FormLabel>
             <textarea
               name="about"
               value={values.about}
-              onChange={handleChange}
-              placeholder="Short description, habits, etc."
+              onChange={handleInputChange}
+              placeholder="Describe more about your pet..."
               rows={4}
-              className="mt-1 w-full rounded-md border border-border bg-white p-3 text-[14px] text-ink placeholder:text-muted-text focus:outline-none focus:ring-2 focus:ring-brand ring-offset-2 ring-offset-bg"
+              className={STYLES.input.textarea}
             />
           </div>
+
+
+          {showDelete && <DeleteButton onDelete={onDelete} />}
+
+
+          <ActionButtons
+            mode={mode}
+            loading={loading}
+            onCancel={onCancel}
+            isMobile={true}
+          />
+          <ActionButtons
+            mode={mode}
+            loading={loading}
+            onCancel={onCancel}
+            isMobile={false}
+          />
         </div>
       </div>
     </form>

--- a/src/components/layout/AccountPageShell.tsx
+++ b/src/components/layout/AccountPageShell.tsx
@@ -1,31 +1,34 @@
 import React from "react";
 import AccountSidebarMini from "@/components/layout/AccountSidebarMini";
+import AccountTabs from "@/components/features/account/AccountTabs";
 
+/**
+ * AccountPageShell
+ * เดสก์ท็อป: Sidebar
+ * มือถือ: Tabs (AccountTabs)
+ */
 export default function AccountPageShell({
   title,
   children,
+  showMobileTabs = true,
 }: {
   title: string;
   children: React.ReactNode;
+  showMobileTabs?: boolean;
 }) {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto max-w-[1200px] px-4 lg:px-6 py-6">
-        <div className="flex flex-col md:flex-row gap-10 lg:gap-8">
-          <aside className="md:w-[292px] flex-shrink-0">
+        <div className="flex flex-col md:flex-row gap-6 md:gap-10 lg:gap-8">
+          <aside className="hidden md:block md:w-[292px] flex-shrink-0">
             <AccountSidebarMini />
           </aside>
 
-          <main className="flex-1 min-w-0">
-            <div className="bg-white rounded-xl ring-1 ring-slate-200 shadow-sm p-8 pb-10">
-              <h1 className="text-h3 font-semibold mb-6 text-slate-900">
-                {title}
-              </h1>
-              <div className="mx-auto w-full max-w-[764px] min-w-0">
-                {children}
-              </div>
-            </div>
-          </main>
+          <section className="flex-1 min-w-0">
+            {showMobileTabs && <AccountTabs className="-mx-4 lg:-mx-1 mb-4" />}
+            <h1 className="hidden md:block text-2xl font-bold mb-4">{title}</h1>
+            {children}
+          </section>
         </div>
       </div>
     </div>

--- a/src/components/ui/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+type Props = {
+  open: boolean;
+  title?: string;
+  message?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmModal({ open, title = "Confirm", message = "Are you sure?", onConfirm, onCancel }: Props) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-[9995] bg-black/40">
+      <div className="min-h-full w-full grid place-items-center p-4">
+        <div className="w-full max-w-md rounded-xl bg-white ring-1 ring-slate-200 shadow-xl p-5">
+          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <p className="text-slate-600 mt-1">{message}</p>
+          <div className="flex justify-end gap-2 mt-4">
+            <button onClick={onCancel} className="px-4 py-2 rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200">Cancel</button>
+            <button onClick={onConfirm} className="px-4 py-2 rounded-lg bg-rose-600 text-white hover:opacity-90">Delete</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/PageToaster.tsx
+++ b/src/components/ui/PageToaster.tsx
@@ -1,0 +1,56 @@
+import { Toaster } from "react-hot-toast";
+
+export default function PageToaster() {
+  const orange      = "var(--brand-orange, #FF7037)";
+  const orange50    = "var(--brand-orange-50, #FFE8DC)";
+  const orange200   = "var(--brand-orange-200, #FFD1BC)";
+  const slate50     = "var(--slate-50, #F8FAFC)";
+  const slate200    = "var(--slate-200, #E2E8F0)";
+  const rose50      = "var(--rose-50, #FFF1F2)";
+  const rose200     = "var(--rose-200, #FECDD3)";
+  const rose700     = "var(--rose-700, #BE123C)";
+  const rose500     = "var(--rose-500, #F43F5E)";
+
+  return (
+    <Toaster
+      position="top-right"
+      toastOptions={{
+        duration: 2500,
+        style: {
+          borderRadius: 14,
+          padding: "10px 14px",
+          boxShadow: "0 10px 30px rgba(16,24,40,.12)",
+        },
+
+
+        success: {
+          style: {
+            background: orange50,
+            color: orange,
+            border: `1px solid ${orange200}`,
+          },
+          iconTheme: { primary: orange, secondary: "#fff" },
+        },
+
+
+        error: {
+          style: {
+            background: rose50,
+            color: rose700,
+            border: `1px solid ${rose200}`,
+          },
+          iconTheme: { primary: rose500, secondary: "#fff" },
+        },
+
+
+        loading: {
+          style: {
+            background: slate50,
+            color: "var(--ink, #111827)",
+            border: `1px solid ${slate200}`,
+          },
+        },
+      }}
+    />
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/hooks/useOwnerProfileForm.ts
+++ b/src/hooks/useOwnerProfileForm.ts
@@ -1,12 +1,33 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  ownerProfileSchema,
-  type OwnerProfileInput,
-} from "@/lib/validators/account";
+import { ownerProfileSchema, type OwnerProfileInput } from "@/lib/validators/account";
+
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
+
+const API_ENDPOINTS = {
+  profile: "/api/user/profile",
+  uniqueCheck: "/api/user/unique-check",
+} as const;
+
+const ERROR_MESSAGES = {
+  nameTaken: "This name is already in use.",
+  emailTaken: "This email is already in use.",
+  phoneTaken: "This phone number is already in use.",
+  invalidDate: "Invalid date. Use YYYY-MM-DD.",
+  unknown: "Unknown error",
+} as const;
+
+const DEFAULT_VALUES: OwnerProfileInput = {
+  name: "",
+  email: "",
+  phone: "",
+  idNumber: "",
+  dob: "",
+  image: undefined,
+};
+
 
 type OwnerProfile = {
   name: string;
@@ -14,91 +35,280 @@ type OwnerProfile = {
   phone: string;
   idNumber?: string | null;
   dob?: string | null;
-  imageUrl?: string | null;
+  profileImage?: string | null;
 };
 
-async function requestJSON<T>(path: string, init?: RequestInit): Promise<T> {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+type UniqueCheckResponse = {
+  unique: boolean;
+};
 
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(init?.headers || {}),
-    },
-    credentials: "include", // ถ้าใช้ cookie-based auth
-  });
+type ValidationField = "name" | "email" | "phone";
 
-  if (!res.ok) {
-    let message = `HTTP ${res.status}`;
-    try {
-      const data = await res.json();
-      if ((data as { message?: string })?.message) message = data.message!;
-    } catch {}
-    throw new Error(message);
+
+const formatDate = {
+  toYmd: (input?: string | null): string | undefined => {
+    if (!input) return undefined;
+    const trimmed = input.trim();
+    const ddmmyyyy = /^(\d{2})[\/-](\d{2})[\/-](\d{4})$/;
+    const yyyymmdd = /^(\d{4})[\/-](\d{2})[\/-](\d{2})$/;
+
+    if (ddmmyyyy.test(trimmed)) {
+      const [, dd, mm, yyyy] = trimmed.match(ddmmyyyy)!;
+      return `${yyyy}-${mm}-${dd}`;
+    }
+    if (yyyymmdd.test(trimmed)) {
+      const [, yyyy, mm, dd] = trimmed.match(yyyymmdd)!;
+      return `${yyyy}-${mm}-${dd}`;
+    }
+    return undefined;
+  },
+};
+
+const sanitize = {
+  onlyDigits: (value?: string | null): string | undefined => {
+    const digits = (value ?? "").replace(/\D/g, "");
+    return digits || undefined;
+  },
+
+  trimString: (value?: string | null): string => {
+    return (value ?? "").trim();
+  },
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return ERROR_MESSAGES.unknown;
   }
-  return (await res.json()) as T;
-}
+};
 
+
+const api = {
+  request: async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers || {}),
+      },
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status}`;
+      try {
+        const contentType = response.headers.get("content-type") || "";
+        const body = contentType.includes("json")
+          ? await response.json()
+          : await response.text();
+
+        if (typeof body === "string") message = body || message;
+        else if (body?.error) message = body.error;
+        else if (body?.message) message = body.message;
+      } catch {
+      }
+      throw new Error(message);
+    }
+
+    return response.status === 204
+      ? (undefined as unknown as T)
+      : ((await response.json()) as T);
+  },
+
+  /**  เช็คซ้ำผ่าน endpoint เดียว */
+  checkUnique: async (field: ValidationField, value: string): Promise<void> => {
+    const data = await api.request<UniqueCheckResponse>(
+      API_ENDPOINTS.uniqueCheck,
+      {
+        method: "POST",
+        body: JSON.stringify({ field, value }),
+      }
+    );
+    if (!data.unique) {
+      throw new Error(`${field}_taken`);
+    }
+  },
+};
+
+const validateUniqueness = {
+  name: async (name?: string | null): Promise<void> => {
+    const trimmed = sanitize.trimString(name);
+    if (!trimmed) return;
+    await api.checkUnique("name", trimmed);
+  },
+
+  email: async (email?: string | null): Promise<void> => {
+    const trimmed = sanitize.trimString(email);
+    if (!trimmed) return;
+    await api.checkUnique("email", trimmed);
+  },
+
+  phone: async (phone?: string | null): Promise<void> => {
+    const digits = sanitize.onlyDigits(phone);
+    if (!digits) return;
+    await api.checkUnique("phone", digits);
+  },
+};
+
+
+const transformData = {
+  fromApiToForm: (profile: OwnerProfile): OwnerProfileInput => ({
+    name: profile?.name ?? "",
+    email: profile?.email ?? "",
+    phone: profile?.phone ?? "",
+    idNumber: profile?.idNumber ?? "",
+    dob: profile?.dob ?? "",
+    image: profile?.profileImage ?? undefined,
+  }),
+
+  fromFormToApi: (values: OwnerProfileInput) => ({
+    name: sanitize.trimString(values.name) || undefined,
+    email: sanitize.trimString(values.email) || undefined,
+    phone: sanitize.onlyDigits(values.phone),
+    dob: formatDate.toYmd(values.dob),
+    profileImage:
+      typeof values.image === "string"
+        ? sanitize.trimString(values.image) || undefined
+        : undefined,
+  }),
+
+  toStorageFormat: (values: OwnerProfileInput): OwnerProfile => ({
+    name: sanitize.trimString(values.name),
+    email: sanitize.trimString(values.email),
+    phone: sanitize.onlyDigits(values.phone) ?? "",
+    idNumber: sanitize.trimString(values.idNumber),
+    dob: formatDate.toYmd(values.dob) ?? "",
+    profileImage:
+      typeof values.image === "string" ? sanitize.trimString(values.image) : "",
+  }),
+};
+
+/* ---- Hook Implementation ---- */
 export function useOwnerProfileForm() {
+  const initialRef = useRef<OwnerProfile | null>(null);
+
   const form = useForm<OwnerProfileInput>({
     resolver: zodResolver(ownerProfileSchema),
     mode: "onBlur",
-    defaultValues: {
-      name: "",
-      email: "",
-      phone: "",
-      idNumber: "",
-      dob: "",
-      image: undefined,
-    },
+    defaultValues: DEFAULT_VALUES,
   });
 
   const load = useCallback(async (): Promise<void> => {
-    const me = await requestJSON<OwnerProfile>("/api/user/get-owner");
-    form.reset({
-      name: me?.name ?? "",
-      email: me?.email ?? "",
-      phone: me?.phone ?? "",
-      idNumber: me?.idNumber ?? "",
-      dob: me?.dob ?? "",
-      image: undefined,
-    });
+    const profile = await api.request<OwnerProfile>(API_ENDPOINTS.profile);
+    const formData = transformData.fromApiToForm(profile);
+
+    initialRef.current = transformData.toStorageFormat(formData);
+    form.reset(formData);
   }, [form]);
 
-  const checkEmailUnique = async (email: string) => {
-    if (!email) return true;
-    try {
-      const ok = await requestJSON<boolean>(
-        `/api/user/check-email?email=${encodeURIComponent(email)}`
-      );
-      return ok || "This email is already taken";
-    } catch {
-      // ถ้าเช็คไม่สำเร็จ อย่าบล็อคผู้ใช้
-      return true;
-    }
-  };
-
-  const checkPhoneUnique = async (phone: string) => {
-    if (!phone) return true;
-    try {
-      const ok = await requestJSON<boolean>(
-        `/api/user/check-phone?phone=${encodeURIComponent(phone)}`
-      );
-      return ok || "This phone is already taken";
-    } catch {
-      return true;
-    }
-  };
-
-  const save = useCallback(async (values: OwnerProfileInput): Promise<void> => {
-    await requestJSON<unknown>("/api/user/put-owner", {
-      method: "PUT",
-      body: JSON.stringify(values),
-    });
+  const checkChanges = useCallback((values: OwnerProfileInput) => {
+    const initial = initialRef.current;
+    return {
+      name: sanitize.trimString(values.name) !== (initial?.name ?? ""),
+      email: sanitize.trimString(values.email) !== (initial?.email ?? ""),
+      phone:
+        sanitize.onlyDigits(values.phone) !==
+        sanitize.onlyDigits(initial?.phone ?? ""),
+    };
   }, []);
+
+  const validateUniqueFields = useCallback(
+    async (values: OwnerProfileInput) => {
+      const changes = checkChanges(values);
+
+      const validationPromises: Promise<void>[] = [
+        changes.name ? validateUniqueness.name(values.name) : Promise.resolve(),
+        changes.email
+          ? validateUniqueness.email(values.email)
+          : Promise.resolve(),
+        changes.phone
+          ? validateUniqueness.phone(values.phone)
+          : Promise.resolve(),
+      ];
+
+      const results = await Promise.allSettled(validationPromises);
+      const [nameResult, emailResult, phoneResult] = results;
+
+      let hasError = false;
+      if (nameResult.status === "rejected") {
+        form.setError("name", { message: ERROR_MESSAGES.nameTaken });
+        hasError = true;
+      }
+      if (emailResult.status === "rejected") {
+        form.setError("email", { message: ERROR_MESSAGES.emailTaken });
+        hasError = true;
+      }
+      if (phoneResult.status === "rejected") {
+        form.setError("phone", { message: ERROR_MESSAGES.phoneTaken });
+        hasError = true;
+      }
+
+      return !hasError;
+    },
+    [form, checkChanges]
+  );
+
+  const save = useCallback(
+    async (values: OwnerProfileInput): Promise<boolean> => {
+      // Check uniqueness first
+      const isUnique = await validateUniqueFields(values);
+      if (!isUnique) return false;
+
+      try {
+        const payload = transformData.fromFormToApi(values);
+
+        await api.request<unknown>(API_ENDPOINTS.profile, {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        });
+
+        initialRef.current = transformData.toStorageFormat(values);
+        return true;
+      } catch (error: unknown) {
+        const message = getErrorMessage(error);
+
+        if (message.includes("email_taken")) {
+          form.setError("email", { message: ERROR_MESSAGES.emailTaken });
+          return false;
+        }
+        if (message.includes("phone_taken")) {
+          form.setError("phone", { message: ERROR_MESSAGES.phoneTaken });
+          return false;
+        }
+        if (message.startsWith("HTTP 400")) {
+          form.setError("dob", { message: ERROR_MESSAGES.invalidDate });
+          return false;
+        }
+        throw error;
+      }
+    },
+    [form, validateUniqueFields]
+  );
+
+  const checkEmailUnique = async (email: string): Promise<true | string> => {
+    const trimmed = sanitize.trimString(email);
+    if (!trimmed) return true;
+    try {
+      await validateUniqueness.email(trimmed);
+      return true;
+    } catch {
+      return ERROR_MESSAGES.emailTaken;
+    }
+  };
+
+  const checkPhoneUnique = async (phone: string): Promise<true | string> => {
+    const digits = sanitize.onlyDigits(phone);
+    if (!digits) return true;
+    try {
+      await validateUniqueness.phone(digits);
+      return true;
+    } catch {
+      return ERROR_MESSAGES.phoneTaken;
+    }
+  };
 
   return { form, load, save, checkEmailUnique, checkPhoneUnique };
 }

--- a/src/hooks/usePets.ts
+++ b/src/hooks/usePets.ts
@@ -1,0 +1,135 @@
+import { useCallback } from "react";
+import type { PetInput } from "@/lib/validators/pet";
+
+/* ---- Types ---- */
+type Pet = {
+  id: number;
+  name: string;
+  petTypeId: number;
+  petTypeName?: string;
+  breed: string;
+  sex: "Male" | "Female";
+  ageMonth: number;
+  color: string;
+  weightKg: number;
+  about?: string;
+  imageUrl?: string;
+};
+
+type PetType = {
+  id: number;
+  name: string;
+};
+
+type ApiResponse<T> = Promise<T>;
+
+/** JSON-safe type สำหรับ request body (เลี่ยง any) */
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | { [k: string]: JsonValue } | JsonValue[];
+
+/* ---- Constants ---- */
+const API_ENDPOINTS = {
+  pets: "/api/pets",
+  petTypes: "/api/pet-types",
+  pet: (id: number) => `/api/pets/${id}`,
+} as const;
+
+const HTTP_METHODS = {
+  GET: "GET",
+  POST: "POST",
+  PUT: "PUT",
+  DELETE: "DELETE",
+} as const;
+
+type HttpMethod = (typeof HTTP_METHODS)[keyof typeof HTTP_METHODS];
+
+/* ---- API Utilities ---- */
+const createRequestConfig = (
+  method: HttpMethod,
+  body?: JsonValue
+): RequestInit => {
+  const hasBody = typeof body !== "undefined";
+  return {
+    method,
+    headers: hasBody ? { "Content-Type": "application/json" } : undefined,
+    credentials: "include",
+    ...(hasBody && { body: JSON.stringify(body) }),
+  };
+};
+
+const handleApiResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+};
+
+const apiRequest = async <T>(url: string, config?: RequestInit): Promise<T> => {
+  const response = await fetch(url, {
+    credentials: "include",
+    ...config,
+  });
+  return handleApiResponse<T>(response);
+};
+
+/* ---- API Functions ---- */
+const petApi = {
+  list: (): ApiResponse<Pet[]> => {
+    return apiRequest<Pet[]>(API_ENDPOINTS.pets);
+  },
+
+  create: (petData: PetInput): ApiResponse<void> => {
+    const config = createRequestConfig(HTTP_METHODS.POST, petData);
+    return apiRequest<void>(API_ENDPOINTS.pets, config);
+  },
+
+  update: (id: number, petData: PetInput): ApiResponse<void> => {
+    const config = createRequestConfig(HTTP_METHODS.PUT, petData);
+    return apiRequest<void>(API_ENDPOINTS.pet(id), config);
+  },
+
+  delete: (id: number): ApiResponse<void> => {
+    const config = createRequestConfig(HTTP_METHODS.DELETE);
+    return apiRequest<void>(API_ENDPOINTS.pet(id), config);
+  },
+};
+
+const petTypeApi = {
+  list: (): ApiResponse<PetType[]> => {
+    return apiRequest<PetType[]>(API_ENDPOINTS.petTypes);
+  },
+};
+
+/* ---- Hook Implementation ---- */
+export function usePetsApi() {
+  const listPets = useCallback(async (): Promise<Pet[]> => {
+    return petApi.list();
+  }, []);
+
+  const getPetTypes = useCallback(async (): Promise<PetType[]> => {
+    return petTypeApi.list();
+  }, []);
+
+  const createPet = useCallback(async (petData: PetInput): Promise<void> => {
+    return petApi.create(petData);
+  }, []);
+
+  const updatePet = useCallback(
+    async (id: number, petData: PetInput): Promise<void> => {
+      return petApi.update(id, petData);
+    },
+    []
+  );
+
+  const deletePet = useCallback(async (id: number): Promise<void> => {
+    return petApi.delete(id);
+  }, []);
+
+  return {
+    listPets,
+    getPetTypes,
+    createPet,
+    updatePet,
+    deletePet,
+  };
+}

--- a/src/lib/pet-utils.ts
+++ b/src/lib/pet-utils.ts
@@ -1,0 +1,189 @@
+import type { NextRouter } from "next/router";
+import type { PetInput } from "@/lib/validators/pet";
+import { Pet, PetFormValues, PetType } from "@/types/pet.types";
+
+
+export type { Pet, PetFormValues, PetType };
+
+
+export const ROUTES = {
+  petList: "/account/pet",
+  createPet: "/account/pet/create",
+  editPet: (id: number) => `/account/pet/${id}`,
+} as const;
+
+export const ERROR_MESSAGES = {
+  loadFailed: "Failed to load pet",
+  updateFailed: "Update failed",
+  deleteFailed: "Delete failed",
+  createFailed: "Create failed",
+  invalidPetType: "Please select a valid Pet Type",
+  unknown: "Unknown error",
+} as const;
+
+export const SUCCESS_MESSAGES = {
+  petCreated: "Pet created!",
+  petUpdated: "Pet updated!",
+  petDeleted: "Pet deleted!",
+} as const;
+
+export const NAVIGATION_DELAY = 900;
+
+
+export const getErrorMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return ERROR_MESSAGES.unknown;
+  }
+};
+
+export const parsePetId = (routerQuery: unknown): number | undefined => {
+  const raw = Array.isArray(routerQuery) ? routerQuery[0] : routerQuery;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+export const validateImageUrl = (url?: string | null): string => {
+  const trimmed = (url ?? "").trim();
+  return trimmed && (trimmed.startsWith("http") || trimmed.startsWith("data:"))
+    ? trimmed
+    : "";
+};
+
+
+export const delayedNavigation = (
+  router: Pick<NextRouter, "push">,
+  path: string,
+  delay: number = NAVIGATION_DELAY
+) => {
+  setTimeout(() => {
+    void router.push(path);
+  }, delay);
+};
+
+
+function toFormSex(value: unknown): PetFormValues["sex"] {
+  return value === "Male" || value === "Female"
+    ? (value as PetFormValues["sex"])
+    : ("Male" as PetFormValues["sex"]); // เปลี่ยน default ได้ตามต้องการ
+}
+
+export const petResponseToFormValues = (pet: Pet): PetFormValues => ({
+  name: pet.name ?? "",
+  type: pet.petTypeName ?? "",
+  breed: pet.breed ?? "",
+  sex: toFormSex(pet.sex),
+  ageMonth: String(pet.ageMonth ?? ""),
+  color: pet.color ?? "",
+  weightKg: String(pet.weightKg ?? ""),
+  about: pet.about ?? "",
+  image: validateImageUrl(pet.imageUrl),
+});
+
+export const formValuesToPayload = async (
+  values: PetFormValues,
+  getPetTypes: () => Promise<PetType[]>
+): Promise<PetInput> => {
+  const petTypes = await getPetTypes();
+  const foundType = petTypes.find(
+    (type) => type.name.toLowerCase() === values.type.toLowerCase()
+  );
+
+  if (!foundType) {
+    throw new Error(ERROR_MESSAGES.invalidPetType);
+  }
+
+  return {
+    petTypeId: foundType.id,
+    name: values.name,
+    breed: values.breed,
+    sex: values.sex as "Male" | "Female",
+    ageMonth: Number(values.ageMonth || 0),
+    color: values.color,
+    weightKg: Number(values.weightKg || 0),
+    about: values.about || "",
+    imageUrl: (values.image ?? "").trim(),
+  };
+};
+
+
+export const petService = {
+  fetchPet: async (id: number): Promise<Pet> => {
+    const response = await fetch(`/api/pets/${id}`, {
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      throw new Error(ERROR_MESSAGES.loadFailed);
+    }
+
+    return (await response.json()) as Pet;
+  },
+
+  updatePet: async (id: number, payload: PetInput): Promise<void> => {
+    const response = await fetch(`/api/pets/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      let errorMessage: string = ERROR_MESSAGES.updateFailed; 
+      try {
+        const errorData = (await response.json()) as unknown;
+        errorMessage =
+          (errorData as { error?: string; message?: string })?.error ||
+          (errorData as { error?: string; message?: string })?.message ||
+          errorMessage;
+      } catch {
+      }
+      throw new Error(errorMessage);
+    }
+  },
+
+  deletePet: async (id: number): Promise<void> => {
+    const response = await fetch(`/api/pets/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      let errorMessage: string = ERROR_MESSAGES.deleteFailed; 
+      try {
+        const errorData = (await response.json()) as unknown;
+        errorMessage =
+          (errorData as { error?: string; message?: string })?.error ||
+          (errorData as { error?: string; message?: string })?.message ||
+          errorMessage;
+      } catch {
+      }
+      throw new Error(errorMessage);
+    }
+  },
+
+  createPet: async (payload: PetInput): Promise<void> => {
+    const response = await fetch("/api/pets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      let errorMessage: string = ERROR_MESSAGES.createFailed; 
+      try {
+        const errorData = (await response.json()) as unknown;
+        errorMessage =
+          (errorData as { error?: string; message?: string })?.error ||
+          (errorData as { error?: string; message?: string })?.message ||
+          errorMessage;
+      } catch {
+      }
+      throw new Error(errorMessage);
+    }
+  },
+};

--- a/src/lib/server/user.map.ts
+++ b/src/lib/server/user.map.ts
@@ -1,11 +1,61 @@
 import type { user } from "@prisma/client";
 
-export const toOwnerProfileDto = (u: Pick<user, "id" | "name" | "email" | "phone" | "dob" | "profile_image">) => ({
-  id: u.id,
-  name: u.name,
-  email: u.email,
-  phone: u.phone ?? "",
-  idNumber: "",                              // ยังไม่มีใน schema
-  dob: u.dob ? u.dob.toISOString().slice(0, 10) : "",
-  profileImage: u.profile_image ?? "",
+
+type UserProfileFields = Pick<user, "id" | "name" | "email" | "phone" | "dob" | "profile_image">;
+
+type OwnerProfileDto = {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  idNumber: string;
+  dob: string;
+  profileImage: string;
+};
+
+
+const DEFAULT_VALUES = {
+  PHONE: "",
+  ID_NUMBER: "",
+  DOB: "",
+  PROFILE_IMAGE: "",
+} as const;
+
+
+const formatters = {
+  dateToString: (date: Date | null): string => {
+    return date ? date.toISOString().slice(0, 10) : DEFAULT_VALUES.DOB;
+  },
+
+  nullableStringToString: (value: string | null): string => {
+    return value ?? "";
+  }
+};
+
+
+export const toOwnerProfileDto = (user: UserProfileFields): OwnerProfileDto => ({
+  id: user.id,
+  name: user.name,
+  email: user.email,
+  phone: formatters.nullableStringToString(user.phone),
+  idNumber: DEFAULT_VALUES.ID_NUMBER,
+  dob: formatters.dateToString(user.dob),
+  profileImage: formatters.nullableStringToString(user.profile_image),
 });
+
+
+export const userMappers = {
+  toOwnerProfile: toOwnerProfileDto,
+  
+  // สำหรับ mapping แบบอื่นในอนาคต
+  toPublicProfile: (user: UserProfileFields) => ({
+    id: user.id,
+    name: user.name,
+    profileImage: formatters.nullableStringToString(user.profile_image),
+  }),
+
+  toMinimalProfile: (user: Pick<user, "id" | "name">) => ({
+    id: user.id,
+    name: user.name,
+  }),
+} as const;

--- a/src/lib/validators/account.ts
+++ b/src/lib/validators/account.ts
@@ -1,25 +1,118 @@
 import { z } from "zod";
 
-export const ownerProfileSchema = z.object({
-  image: z.any().optional(), 
+
+const VALIDATION_RULES = {
+  name: {
+    min: 6,
+    max: 20,
+  },
+  phone: {
+    length: 10,
+    pattern: /^0\d{9}$/,
+  },
+  idNumber: {
+    length: 13,
+    pattern: /^\d{13}$/,
+  },
+} as const;
+
+const ERROR_MESSAGES = {
+  name: {
+    required: "Your name is required",
+    length: `Name must be ${VALIDATION_RULES.name.min}–${VALIDATION_RULES.name.max} characters`,
+  },
+  email: {
+    required: "Email is required",
+    format: "Invalid email format",
+  },
+  phone: {
+    required: "Phone is required",
+    format: "Phone must start with 0 and be 10 digits",
+  },
+  idNumber: {
+    format: "ID must be 13 digits",
+  },
+} as const;
+
+
+const validators = {
   name: z
     .string()
-    .min(1, "Your name is required")
-    .min(6, "Name must be 6–20 characters")
-    .max(20, "Name must be 6–20 characters"),
+    .min(1, ERROR_MESSAGES.name.required)
+    .min(VALIDATION_RULES.name.min, ERROR_MESSAGES.name.length)
+    .max(VALIDATION_RULES.name.max, ERROR_MESSAGES.name.length),
+
   email: z
     .string()
-    .min(1, "Email is required")
-    .email("Invalid email format"),
+    .min(1, ERROR_MESSAGES.email.required)
+    .email(ERROR_MESSAGES.email.format),
+
   phone: z
     .string()
-    .min(1, "Phone is required")
-    .regex(/^0\d{9}$/, "Phone must start with 0 and be 10 digits"),
+    .min(1, ERROR_MESSAGES.phone.required)
+    .regex(VALIDATION_RULES.phone.pattern, ERROR_MESSAGES.phone.format),
+
   idNumber: z
     .string()
     .optional()
-    .refine((v) => !v || /^\d{13}$/.test(v), "ID must be 13 digits"),
+    .refine(
+      (value) => !value || VALIDATION_RULES.idNumber.pattern.test(value),
+      ERROR_MESSAGES.idNumber.format
+    ),
+
   dob: z.string().optional(),
+
+  image: z.any().optional(),
+} as const;
+
+
+export const ownerProfileSchema = z.object({
+  image: validators.image,
+  name: validators.name,
+  email: validators.email,
+  phone: validators.phone,
+  idNumber: validators.idNumber,
+  dob: validators.dob,
 });
 
 export type OwnerProfileInput = z.infer<typeof ownerProfileSchema>;
+
+
+export const profileSchemas = {
+
+  full: ownerProfileSchema,
+
+  required: z.object({
+    name: validators.name,
+    email: validators.email,
+    phone: validators.phone,
+  }),
+
+  public: z.object({
+    name: validators.name,
+    image: validators.image,
+  }),
+
+  update: z.object({
+    name: validators.name.optional(),
+    email: validators.email.optional(),
+    phone: validators.phone.optional(),
+    idNumber: validators.idNumber,
+    dob: validators.dob,
+    image: validators.image,
+  }),
+} as const;
+
+
+export const profileValidation = {
+  validateName: (name: string) => validators.name.safeParse(name),
+  validateEmail: (email: string) => validators.email.safeParse(email),
+  validatePhone: (phone: string) => validators.phone.safeParse(phone),
+  validateIdNumber: (idNumber: string) => validators.idNumber.safeParse(idNumber),
+  
+  
+  getFieldErrors: (result: ReturnType<typeof validators.name.safeParse>) => {
+    if (result.success) return null;
+    return result.error.issues.map((err: z.ZodIssue) => err.message);
+  },
+} as const;

--- a/src/lib/validators/pet.ts
+++ b/src/lib/validators/pet.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+
+const VALIDATION_RULES = {
+  petTypeId: {
+    min: 1,
+  },
+  ageMonth: {
+    min: 0,
+  },
+  weight: {
+    min: 0,
+  },
+} as const;
+
+const ERROR_MESSAGES = {
+  petType: "Select a pet type",
+  name: "Name is required",
+  breed: "Breed is required", 
+  ageMonth: {
+    integer: "Age (month) must be an integer",
+    min: "Age (month) must be 0 or more",
+  },
+  color: "Color is required",
+  weight: "Weight must be greater than 0",
+} as const;
+
+
+export const sexEnum = z.enum(["Male", "Female"]);
+
+const validators = {
+  petTypeId: z
+    .number()
+    .refine(
+      (value) => Number.isInteger(value) && value > VALIDATION_RULES.petTypeId.min - 1,
+      ERROR_MESSAGES.petType
+    ),
+
+  name: z
+    .string()
+    .trim()
+    .min(1, ERROR_MESSAGES.name),
+
+  breed: z
+    .string()
+    .trim()
+    .min(1, ERROR_MESSAGES.breed),
+
+  sex: sexEnum,
+
+  ageMonth: z
+    .number()
+    .refine(
+      (value) => Number.isInteger(value),
+      ERROR_MESSAGES.ageMonth.integer
+    )
+    .min(VALIDATION_RULES.ageMonth.min, ERROR_MESSAGES.ageMonth.min),
+
+  color: z
+    .string()
+    .trim()
+    .min(1, ERROR_MESSAGES.color),
+
+  weightKg: z
+    .number()
+    .refine(
+      (value) => value > VALIDATION_RULES.weight.min,
+      ERROR_MESSAGES.weight
+    ),
+
+  about: z
+    .string()
+    .trim()
+    .optional()
+    .or(z.literal("")),
+
+  imageUrl: z
+    .string()
+    .trim()
+    .optional()
+    .or(z.literal("")),
+} as const;
+
+
+export const petSchema = z.object({
+  petTypeId: validators.petTypeId,
+  name: validators.name,
+  breed: validators.breed,
+  sex: validators.sex,
+  ageMonth: validators.ageMonth,
+  color: validators.color,
+  weightKg: validators.weightKg,
+  about: validators.about,
+  imageUrl: validators.imageUrl,
+});
+
+export type PetInput = z.infer<typeof petSchema>;
+
+
+export const petSchemas = {
+  full: petSchema,
+
+  required: z.object({
+    petTypeId: validators.petTypeId,
+    name: validators.name,
+    breed: validators.breed,
+    sex: validators.sex,
+    ageMonth: validators.ageMonth,
+    color: validators.color,
+    weightKg: validators.weightKg,
+  }),
+
+  update: z.object({
+    petTypeId: validators.petTypeId.optional(),
+    name: validators.name.optional(),
+    breed: validators.breed.optional(),
+    sex: validators.sex.optional(),
+    ageMonth: validators.ageMonth.optional(),
+    color: validators.color.optional(),
+    weightKg: validators.weightKg.optional(),
+    about: validators.about,
+    imageUrl: validators.imageUrl,
+  }),
+
+  public: z.object({
+    name: validators.name,
+    breed: validators.breed,
+    sex: validators.sex,
+    ageMonth: validators.ageMonth,
+    color: validators.color,
+    weightKg: validators.weightKg,
+    about: validators.about,
+    imageUrl: validators.imageUrl,
+  }),
+} as const;
+
+
+export const petValidation = {
+  validatePetTypeId: (id: number) => validators.petTypeId.safeParse(id),
+  validateName: (name: string) => validators.name.safeParse(name),
+  validateBreed: (breed: string) => validators.breed.safeParse(breed),
+  validateSex: (sex: string) => validators.sex.safeParse(sex),
+  validateAge: (age: number) => validators.ageMonth.safeParse(age),
+  validateColor: (color: string) => validators.color.safeParse(color),
+  validateWeight: (weight: number) => validators.weightKg.safeParse(weight),
+
+
+  getFieldErrors: (result: ReturnType<typeof validators.name.safeParse>) => {
+    if (result.success) return null;
+    return result.error.issues.map((err: z.ZodIssue) => err.message);
+  },
+
+  isCompleteForCreation: (data: Partial<PetInput>): data is PetInput => {
+    return petSchemas.required.safeParse(data).success;
+  },
+} as const;
+
+
+export type Sex = z.infer<typeof sexEnum>;
+export type PetUpdateInput = z.infer<typeof petSchemas.update>;
+export type PetPublicView = z.infer<typeof petSchemas.public>;
+
+
+export const petInputSchema = petSchema;

--- a/src/pages/account/pet/[id].tsx
+++ b/src/pages/account/pet/[id].tsx
@@ -1,76 +1,200 @@
 import * as React from "react";
 import { useRouter } from "next/router";
+import toast from "react-hot-toast";
 import AccountPageShell from "@/components/layout/AccountPageShell";
 import PetForm from "@/components/features/pet/PetForm";
-import type { PetFormValues } from "@/types/pet.types";
-import AlertConfirm from "@/components/modal/AlertConfirm";
+import PageToaster from "@/components/ui/PageToaster";
+import { usePetsApi } from "@/hooks/usePets";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  PetFormValues,
+  ROUTES,
+  SUCCESS_MESSAGES,
+  getErrorMessage,
+  parsePetId,
+  petResponseToFormValues,
+  formValuesToPayload,
+  petService,
+  delayedNavigation
+} from "@/lib/pet-utils";
 
-const MOCK: Record<string, PetFormValues> = {
-  "1": { name: "Bubba", type: "Dog", breed: "Pit Bull", sex: "Male", ageMonth: "12", color: "Gray", weightKg: "25", about: "", image: "/images/demo/bubba.svg" },
-  "2": { name: "Daisy", type: "Dog", breed: "Beagle", sex: "Female", ageMonth: "0.6", color: "White, black and brown", weightKg: "2", about: "", image: "/images/demo/daisy.svg" },
-  "3": { name: "I Som", type: "Cat", breed: "Ginger", sex: "Male", ageMonth: "18", color: "Orange", weightKg: "4.5", about: "", image: "/images/demo/isom.svg" },
-  "4": { name: "Noodle Birb", type: "Bird", breed: "Parakeet", sex: "Female", ageMonth: "10", color: "Green", weightKg: "0.2", about: "", image: "/images/demo/bird.svg" },
-};
-
-export default function PetDetailPage() {
+/* ---- Component ---- */
+export default function EditPetPage() {
   const router = useRouter();
-  const ready = router.isReady;
-  const id = ready ? (router.query.id as string) : undefined;
-
-  const initial = React.useMemo(
-    () => (id ? MOCK[id] : undefined),
-    [id]
+  const { getPetTypes } = usePetsApi();
+  
+  // Parse pet ID from router
+  const petId = React.useMemo(
+    () => parsePetId(router.query.id),
+    [router.query.id]
   );
 
-  const [confirmOpen, setConfirmOpen] = React.useState(false);
+  // Component state
+  const [loading, setLoading] = React.useState(true);
+  const [serverError, setServerError] = React.useState<string | null>(null);
+  const [initialValues, setInitialValues] = React.useState<PetFormValues | null>(null);
+  const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
 
-  if (!ready) return null;
+  // Load pet data on mount
+  React.useEffect(() => {
+    if (!petId) return;
 
+    let isMounted = true;
 
-  const description = (
-    <div className="space-y-4">
-      <p className="text-slate-600">Are you sure to delete this pet?</p>
-      <div className="flex items-center justify-end gap-3 pt-1">
-        <button
-          onClick={() => setConfirmOpen(false)}
-          className="rounded-full bg-orange-50 px-4 py-2 text-sm font-medium text-orange-600"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={async () => {
-            console.log("delete", id);
-            setConfirmOpen(false);
-            router.push("/account/pet");
-          }}
-          className="rounded-full bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600"
-        >
-          Delete
-        </button>
-      </div>
-    </div>
-  );
+    const loadPet = async () => {
+      try {
+        setLoading(true);
+        setServerError(null);
+        
+        const pet = await petService.fetchPet(petId);
+        
+        if (isMounted) {
+          const formValues = petResponseToFormValues(pet);
+          setInitialValues(formValues);
+        }
+      } catch (error) {
+        if (isMounted) {
+          const errorMessage = getErrorMessage(error);
+          setServerError(errorMessage);
+          toast.error(errorMessage);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadPet();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [petId]);
+
+  // Event handlers
+  const handleSubmit = async (values: PetFormValues) => {
+    if (!petId) return;
+
+    try {
+      const payload = await formValuesToPayload(values, getPetTypes);
+      await petService.updatePet(petId, payload);
+      
+      toast.success(SUCCESS_MESSAGES.petUpdated);
+      delayedNavigation(router, ROUTES.petList);
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage);
+      console.error("Update pet failed:", error);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!petId) return;
+
+    try {
+      await petService.deletePet(petId);
+      toast.success(SUCCESS_MESSAGES.petDeleted);
+      delayedNavigation(router, ROUTES.petList);
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage);
+      console.error("Delete pet failed:", error);
+    } finally {
+      setShowDeleteDialog(false);
+    }
+  };
+
+  const handleCancel = () => {
+    router.push(ROUTES.petList);
+  };
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  const handleShowDeleteDialog = () => {
+    setShowDeleteDialog(true);
+  };
 
   return (
     <AccountPageShell title="Your Pet">
-      <PetForm
-        mode="edit"
-        initialValues={initial}    
-        onSubmit={async (values) => {
-            console.log("update", id, values);
-            router.push("/account/pet");
-        }}
-        onCancel={() => router.push("/account/pet")}
-        onDelete={() => setConfirmOpen(true)}
-      />
+      <PageToaster />
 
-      <AlertConfirm
-        open={confirmOpen}
-        onOpenChange={setConfirmOpen}
-        title="Delete Confirmation"
-        width={400}
-        description={description}
-      />
+
+      <div className="mb-4 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleGoBack}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full hover:bg-muted/60"
+          aria-label="Go back"
+          title="Back"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+            <path 
+              d="M15 19L8 12L15 5" 
+              stroke="currentColor" 
+              strokeWidth="2" 
+              strokeLinecap="round" 
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <h1 className="text-2xl font-bold text-ink">Your Pet</h1>
+      </div>
+
+      {loading ? (
+        <div className="text-slate-600">Loading...</div>
+      ) : (
+        <>
+          <PetForm
+            mode="edit"
+            initialValues={initialValues ?? undefined}
+            serverError={serverError}
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+            onDelete={handleShowDeleteDialog}
+          />
+
+
+          <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+            <AlertDialogContent className="p-0 rounded-2xl font-[700] border-transparent w-[90vw] max-w-[400px]">
+              <div className="p-3 pl-5 flex justify-between items-center border-b border-gray-2">
+                <AlertDialogTitle className="text-black text-[20px]">
+                  Delete Confirmation
+                </AlertDialogTitle>
+                <AlertDialogCancel className="text-gray-4 border-transparent shadow-transparent hover:text-gray-9 text-[17px]">
+                  ✕
+                </AlertDialogCancel>
+              </div>
+
+ 
+              <div className="pl-5 pr-4 pt-4 pb-2 text-[16px] font-normal text-ink/80">
+                Are you sure to delete this pet?
+              </div>
+
+
+              <div className="px-4 pb-4 pt-2 grid grid-cols-2 gap-3">
+                <AlertDialogCancel className="h-11 rounded-full bg-orange-1/40 text-orange-6 font-semibold hover:bg-orange-1/60 transition">
+                  Cancel
+                </AlertDialogCancel>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="h-11 rounded-full bg-brand text-white font-bold hover:brightness-95 transition"
+                >
+                  Delete
+                </button>
+              </div>
+            </AlertDialogContent>
+          </AlertDialog>
+        </>
+      )}
     </AccountPageShell>
   );
 }

--- a/src/pages/account/pet/create.tsx
+++ b/src/pages/account/pet/create.tsx
@@ -1,24 +1,55 @@
 import * as React from "react";
 import { useRouter } from "next/router";
+import toast from "react-hot-toast";
 import AccountPageShell from "@/components/layout/AccountPageShell";
 import PetForm from "@/components/features/pet/PetForm";
-import type { PetFormValues } from "@/types/pet.types";
+import PageToaster from "@/components/ui/PageToaster";
+import { usePetsApi } from "@/hooks/usePets";
+import {
+  PetFormValues,
+  ROUTES,
+  SUCCESS_MESSAGES,
+  getErrorMessage,
+  formValuesToPayload,
+  petService,
+  delayedNavigation
+} from "@/lib/pet-utils";
+
 
 export default function CreatePetPage() {
   const router = useRouter();
+  const { getPetTypes } = usePetsApi();
 
   const handleSubmit = async (values: PetFormValues) => {
-    // รอ POST /api/pet
-    console.log("Create Pet:", values);
-    router.push("/account/pet");
+    try {
+
+      const payload = await formValuesToPayload(values, getPetTypes);
+      
+      // Create pet via API
+      await petService.createPet(payload);
+      
+      // Show success message and navigate
+      toast.success(SUCCESS_MESSAGES.petCreated);
+      delayedNavigation(router, ROUTES.petList);
+      
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage);
+      console.error("Create pet failed:", error);
+    }
+  };
+
+  const handleCancel = () => {
+    router.push(ROUTES.petList);
   };
 
   return (
     <AccountPageShell title="Your Pet">
+      <PageToaster />
       <PetForm
         mode="create"
         onSubmit={handleSubmit}
-        onCancel={() => router.push("/account/pet")}
+        onCancel={handleCancel}
       />
     </AccountPageShell>
   );

--- a/src/pages/account/pet/index.tsx
+++ b/src/pages/account/pet/index.tsx
@@ -1,53 +1,112 @@
 import * as React from "react";
-import Link from "next/link";
 import { useRouter } from "next/router";
+import toast from "react-hot-toast";
 import AccountPageShell from "@/components/layout/AccountPageShell";
 import PetCard from "@/components/cards/PetCard";
-import type { Pet } from "@/types/pet.types";
+import CreateNewPetCard from "@/components/cards/CreateNewPetCard";
+import { usePetsApi } from "@/hooks/usePets";
+import {
+  Pet,
+  ROUTES,
+  getErrorMessage,
+  validateImageUrl,
+} from "@/lib/pet-utils";
 
-type Species = "Dog" | "Cat" | "Bird" | "Rabbit" | (string & {});
-
-
-const toSpecies = (t: string): Species => {
-  const known = ["Dog", "Cat", "Bird", "Rabbit"] as const;
-  return (known as readonly string[]).includes(t) ? (t as Species) : (t as Species);
-};
-
-const pets: Pet[] = [
-  { id: 1, name: "Bubba", type: "Dog", image: "/images/demo/bubba.svg" } as Pet,
-  { id: 2, name: "Daisy", type: "Dog", image: "/images/demo/daisy.svg" } as Pet,
-  { id: 3, name: "I Som", type: "Cat", image: "/images/demo/isom.svg" } as Pet,
-  { id: 4, name: "Noodle Birb", type: "Bird", image: "/images/demo/bird.svg" } as Pet,
-];
 
 export default function PetListPage() {
   const router = useRouter();
+  const { listPets } = usePetsApi();
+
+  const [pets, setPets] = React.useState<Pet[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  // Load pets on mount
+  React.useEffect(() => {
+    const loadPets = async () => {
+      try {
+        setLoading(true);
+        const data = await listPets();
+        setPets(data);
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        toast.error(errorMessage);
+        console.error("Failed to load pets:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPets();
+  }, [listPets]);
+
+  // Handlers: ทำให้เสถียรด้วย useCallback
+  const handleCreatePet = React.useCallback(() => {
+    router.push(ROUTES.createPet);
+  }, [router]);
+
+  const handleEditPet = React.useCallback(
+    (petId: number) => {
+      router.push(ROUTES.editPet(petId));
+    },
+    [router]
+  );
+
+  // เตรียมพร็อพที่ผ่านเข้า Card ให้ “คงตัว” ด้วย useMemo
+  // - แปลงรูปให้เรียบร้อย
+  // - เก็บ id ไว้สำหรับ onClickId เพื่อลดการสร้างฟังก์ชัน inline
+  const viewPets = React.useMemo(
+    () =>
+      pets.map((p) => ({
+        id: p.id,
+        name: p.name,
+        species: p.petTypeName ?? "",
+        img: validateImageUrl(p.imageUrl),
+      })),
+    [pets]
+  );
+
+
+  if (loading) {
+    return (
+      <AccountPageShell title="Your Pet">
+        <div className="text-slate-600">Loading...</div>
+      </AccountPageShell>
+    );
+  }
 
   return (
     <AccountPageShell title="Your Pet">
-      <div className="mb-6 flex items-center justify-end">
-        <Link
-          href="/account/pet/create"
-          className="rounded-full bg-brand px-5 py-2.5 text-white text-sm font-semibold hover:brightness-95 hover:shadow cursor-pointer"
+
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900">All Pets</h2>
+        <button
+          onClick={handleCreatePet}
+          className="rounded-full bg-[var(--brand-orange-500,#FF7037)] px-4 py-2 font-semibold text-white hover:opacity-90"
         >
           Create Pet
-        </Link>
+        </button>
       </div>
 
-      <div className="grid min-w-0 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {pets.map((p) => (
-          <div key={p.id} className="min-w-0 flex justify-center">
-            <PetCard
-              name={p.name}
-              species={toSpecies((p as { type?: string }).type ?? "")}
-              img={(p as { image?: string }).image ?? ""}
-              width={180}
-              height={209}
-              avatarSize={96}
-              onClick={() => router.push(`/account/pet/${p.id}`)}
-            />
-          </div>
+
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+
+        {viewPets.length === 0 && <CreateNewPetCard onClick={handleCreatePet} />}
+
+
+        {viewPets.map((p) => (
+          <PetCard
+            key={p.id}
+            id={p.id}              
+            name={p.name}
+            species={p.species}
+            img={p.img}
+            onClickId={handleEditPet}
+            size={260}
+          />
         ))}
+
+
+        {viewPets.length > 0 && <CreateNewPetCard onClick={handleCreatePet} />}
       </div>
     </AccountPageShell>
   );

--- a/src/pages/account/profile.tsx
+++ b/src/pages/account/profile.tsx
@@ -1,108 +1,129 @@
-import React, { useEffect, useState } from "react";
-import { useOwnerProfileForm } from "@/hooks/useOwnerProfileForm";
+import * as React from "react";
+import { useEffect, useState } from "react";
+import type { GetServerSideProps, NextPage } from "next";
+import toast from "react-hot-toast";
+import { getServerSession } from "next-auth/next";
+
 import AccountPageShell from "@/components/layout/AccountPageShell";
 import ProfileForm from "@/components/features/account/ProfileForm";
-import Navbar from "@/components/navbar/Navbar";
-import toast, { Toaster } from "react-hot-toast";
-import { useSession } from "next-auth/react"; // NextAuth session hook
-import { useRouter } from "next/router"; 
+import PageToaster from "@/components/ui/PageToaster";
+import { useOwnerProfileForm } from "@/hooks/useOwnerProfileForm";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import type { OwnerProfileInput } from "@/lib/validators/account";
 
-function getErrorMessage(e: unknown, fallback: string): string {
-  return e instanceof Error ? e.message : fallback;
-}
 
-export default function AccountProfilePage() {
-  const { data: session, status } = useSession(); // NextAuth session
-  const router = useRouter();
-  const { form, load, save } = useOwnerProfileForm();
-  const [loading, setLoading] = useState(true);
+const ERROR_MESSAGES = {
+  loadFailed: "Failed to load profile.",
+  saveFailed: "Something went wrong. Please try again.",
+  fixFields: "Please fix the highlighted fields.",
+  unknown: "Something went wrong.",
+} as const;
+
+const SUCCESS_MESSAGES = {
+  profileUpdated: "Profile updated!",
+} as const;
+
+
+const getErrorMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "Unknown error";
+  }
+};
+
+const useProfileLoader = (loadProfileFn: () => Promise<void>) => {
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadProfile = async () => {
+      try {
+        await loadProfileFn();
+      } catch (error) {
+        if (!isMounted) return;
+        console.error("Profile load error:", error);
+        toast.error(ERROR_MESSAGES.loadFailed);
+      }
+    };
+
+    loadProfile();
+    return () => {
+      isMounted = false;
+    };
+  }, [loadProfileFn]);
+};
+
+const useProfileSubmission = (
+  saveProfileFn: (values: OwnerProfileInput) => Promise<boolean>
+) => {
+  const [saving, setSaving] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
-  useEffect(() => {
-    // Replace localStorage token check with NextAuth session check
-    if (status === 'loading') return; // Wait for session to load
-    if (!session?.user) {
-      router.push("/auth/login");
-      return;
-    }
-    (async () => {
-      try {
-        await load();
-      } catch (e: unknown) {
-        const msg = getErrorMessage(e, "Failed to load profile");
-        setServerError(msg);
-        toast.error(msg);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [session, status, router, load]); // Add NextAuth dependencies
-
-  const onSubmit = form.handleSubmit(async (values) => {
+  const submitProfile = async (values: OwnerProfileInput) => {
     setServerError(null);
-    const t = toast.loading("Updating profile…");
+    setSaving(true);
+
     try {
-      await save(values);
-      toast.success("Profile updated!", { id: t });
-    } catch (e: unknown) {
-      const msg = getErrorMessage(e, "Failed to save");
-      setServerError(msg);
-      toast.error(msg, { id: t });
+      const success = await saveProfileFn(values);
+      if (success) {
+        toast.success(SUCCESS_MESSAGES.profileUpdated);
+      } else {
+        toast.error(ERROR_MESSAGES.fixFields);
+      }
+    } catch (error) {
+      console.error("Profile save error:", error);
+      const errorMessage = getErrorMessage(error);
+      setServerError(errorMessage || ERROR_MESSAGES.unknown);
+      toast.error(ERROR_MESSAGES.saveFailed);
+    } finally {
+      setSaving(false);
     }
-  });
+  };
+
+  return {
+    saving,
+    serverError,
+    submitProfile,
+  };
+};
+
+const AccountProfilePage: NextPage = () => {
+  const { form, load, save } = useOwnerProfileForm();
+  const { saving, serverError, submitProfile } = useProfileSubmission(save);
+
+  useProfileLoader(load);
+
+  const handleSubmit = form.handleSubmit(submitProfile);
 
   return (
-    <>
-      <Navbar />
-      <AccountPageShell title="Profile">
-        {loading ? (
-          <p className="text-slate-500">Loading…</p>
-        ) : (
-          <ProfileForm
-            control={form.control}
-            onSubmit={onSubmit}
-            saving={form.formState.isSubmitting}
-            serverError={serverError}
-          />
-        )}
-      </AccountPageShell>
-
-   
-      <Toaster
-  position="top-right"
-  containerStyle={{ zIndex: 2147483647 }}
-  toastOptions={{
-    style: {
-      background: "var(--brand)",
-      color: "var(--on-brand)",
-    },
-    className: "toast-brand",
-    success: {
-
-      iconTheme: {
-        primary: "var(--brand)",
-        secondary: "var(--on-brand)",
-      },
- 
-      className: "toast-brand",
-      style: {
-        background: "var(--brand)",
-        color: "var(--on-brand)",
-      },
-    },
-    error: {
-      iconTheme: {
-        primary: "var(--brand)",
-        secondary: "var(--on-brand)",
-      },
-      className: "toast-brand",
-      style: {
-        background: "var(--brand)",
-        color: "var(--on-brand)",
-      },
-    },
-  }}
-/>
-    </>
+    <AccountPageShell title="Profile">
+      <PageToaster />
+      <ProfileForm
+        control={form.control}
+        saving={saving}
+        serverError={serverError}
+        onSubmit={handleSubmit}
+      />
+    </AccountPageShell>
   );
-}
+};
+
+export default AccountProfilePage;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+
+  if (!session) {
+    const callbackUrl = encodeURIComponent(context.resolvedUrl || "/account/profile");
+    return {
+      redirect: {
+        destination: `/api/auth/signin?callbackUrl=${callbackUrl}`,
+        permanent: false, // 302
+      },
+    };
+  }
+
+  return { props: {} };
+};

--- a/src/pages/api/pet-types/index.ts
+++ b/src/pages/api/pet-types/index.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+
+type PetTypeResponse = {
+  id: number;
+  name: string;
+};
+
+type ErrorResponse = {
+  error: string;
+};
+
+
+const HTTP_STATUS = {
+  OK: 200,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+const ERROR_MESSAGES = {
+  INTERNAL_SERVER_ERROR: "Internal Server Error",
+} as const;
+
+const petTypeRepository = {
+  findAll: async (): Promise<PetTypeResponse[]> => {
+    const types = await prisma.pet_type.findMany({
+      orderBy: { id: "asc" },
+      select: { 
+        id: true, 
+        pet_type_name: true 
+      },
+    });
+
+    return types.map(type => ({
+      id: type.id,
+      name: type.pet_type_name,
+    }));
+  },
+};
+
+const handleError = (error: unknown, res: NextApiResponse<ErrorResponse>) => {
+  console.error("Pet types API error:", error);
+  
+  return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+    error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+  });
+};
+
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<PetTypeResponse[] | ErrorResponse>
+) {
+  try {
+    const petTypes = await petTypeRepository.findAll();
+    
+    return res.status(HTTP_STATUS.OK).json(petTypes);
+  } catch (error) {
+    return handleError(error, res);
+  }
+}

--- a/src/pages/api/pets/[id].ts
+++ b/src/pages/api/pets/[id].ts
@@ -1,0 +1,80 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import { petSchema } from "@/lib/validators/pet";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  const userIdStr = session?.user?.id;
+  if (!userIdStr) return res.status(401).json({ error: "Unauthorized" });
+
+  const userId = Number(userIdStr);
+  if (!Number.isFinite(userId)) return res.status(400).json({ error: "Invalid user id" });
+
+  const id = Number(req.query.id);
+  if (!Number.isFinite(id)) return res.status(400).json({ error: "Invalid id" });
+
+  try {
+    if (req.method === "GET") {
+      const pet = await prisma.pet.findFirst({
+        where: { id, owner_id: userId },
+        include: { pet_type: true },
+      });
+      if (!pet) return res.status(404).json({ error: "Pet not found" });
+
+      return res.status(200).json({
+        id: pet.id,
+        name: pet.name,
+        breed: pet.breed,
+        sex: pet.sex as "Male" | "Female",
+        ageMonth: pet.age_month,
+        color: pet.color,
+        weightKg: Number(pet.weight_kg),
+        about: pet.about ?? "",
+        imageUrl: pet.image_url || undefined,
+        petTypeId: pet.pet_type_id,
+        petTypeName: pet.pet_type?.pet_type_name ?? "",
+      });
+    }
+
+    if (req.method === "PUT") {
+      const parsed = petSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ error: "Validation error", details: parsed.error.flatten() });
+      }
+      const data = parsed.data;
+
+      const updated = await prisma.pet.updateMany({
+        where: { id, owner_id: userId },
+        data: {
+          pet_type_id: data.petTypeId,
+          name: data.name,
+          breed: data.breed,
+          sex: data.sex,
+          age_month: data.ageMonth,
+          color: data.color,
+          weight_kg: data.weightKg,
+          about: data.about,
+          image_url: data.imageUrl,
+          updated_at: new Date(),
+        },
+      });
+      if (updated.count === 0) return res.status(404).json({ error: "Pet not found" });
+
+      return res.status(200).json({ message: "OK" });
+    }
+
+    if (req.method === "DELETE") {
+      const result = await prisma.pet.deleteMany({ where: { id, owner_id: userId } });
+      if (result.count === 0) return res.status(404).json({ error: "Pet not found" });
+      return res.status(200).json({ message: "Deleted" });
+    }
+
+    res.setHeader("Allow", ["GET", "PUT", "DELETE"]);
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (err) {
+    console.error("pet [id] api error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+}

--- a/src/pages/api/pets/index.ts
+++ b/src/pages/api/pets/index.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { prisma } from "@/lib/prisma";
+
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  const userIdStr = session?.user?.id;
+  if (!userIdStr) return res.status(401).json({ error: "Unauthorized" });
+
+  const ownerId = Number(userIdStr);
+  if (!Number.isFinite(ownerId)) return res.status(400).json({ error: "Invalid user id" });
+
+  try {
+    if (req.method === "GET") {
+      const pets = await prisma.pet.findMany({
+        where: { owner_id: ownerId },
+        orderBy: { id: "asc" },
+        include: { pet_type: true },
+      });
+      return res.status(200).json(
+        pets.map(p => ({
+          id: p.id,
+          name: p.name,
+          petTypeId: p.pet_type_id,
+          petTypeName: p.pet_type?.pet_type_name ?? "",
+          breed: p.breed,
+          sex: p.sex as "Male" | "Female",
+          ageMonth: p.age_month,
+          color: p.color,
+          weightKg: Number(p.weight_kg),
+          about: p.about ?? "",
+          imageUrl: p.image_url ?? "",
+        }))
+      );
+    }
+
+
+    if (req.method === "POST") {
+      const {
+        petTypeId,
+        name,
+        breed,
+        sex,
+        ageMonth,
+        color,
+        weightKg,
+        about,
+        imageUrl,
+      } = req.body || {};
+
+      const errors: Record<string, string[]> = {};
+
+      if (typeof petTypeId !== "number") errors.petTypeId = ["petTypeId must be a number"];
+      if (typeof name !== "string" || !name.trim()) errors.name = ["Name is required"];
+      if (typeof breed !== "string" || !breed.trim()) errors.breed = ["Breed is required"];
+      if (sex !== "Male" && sex !== "Female") errors.sex = ["Sex must be 'Male' or 'Female'"];
+      if (typeof ageMonth !== "number" || ageMonth < 0) errors.ageMonth = ["ageMonth must be a non-negative number"];
+      if (typeof color !== "string" || !color.trim()) errors.color = ["Color is required"];
+      if (typeof weightKg !== "number" || weightKg < 0) errors.weightKg = ["weightKg must be a non-negative number"];
+
+
+      if (Object.keys(errors).length > 0) {
+        return res.status(400).json({ error: "Validation", details: errors });
+      }
+
+      const data = {
+        petTypeId,
+        name,
+        breed,
+        sex,
+        ageMonth,
+        color,
+        weightKg,
+        about,
+        imageUrl,
+      };
+
+      const created = await prisma.pet.create({
+        data: {
+          owner_id: ownerId,
+          pet_type_id: data.petTypeId,
+          name: data.name,
+          breed: data.breed,
+          sex: data.sex,
+          age_month: data.ageMonth,
+          color: data.color,
+          weight_kg: data.weightKg,
+          about: data.about || null,
+          image_url: data.imageUrl || null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        include: { pet_type: true },
+      });
+
+      return res.status(201).json({
+        id: created.id,
+        name: created.name,
+        petTypeId: created.pet_type_id,
+        petTypeName: created.pet_type?.pet_type_name ?? "",
+      });
+    }
+
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (e) {
+    console.error("pets api error:", e);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+}

--- a/src/pages/api/pets/types.ts
+++ b/src/pages/api/pets/types.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const types = await prisma.pet_type.findMany({
+      orderBy: { pet_type_name: "asc" },
+      select: { id: true, pet_type_name: true },
+    });
+    return res.status(200).json(types.map(t => ({ id: t.id, name: t.pet_type_name })));
+  } catch (err) {
+    console.error("pet types api error:", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+}

--- a/src/pages/api/user/get-owner.ts
+++ b/src/pages/api/user/get-owner.ts
@@ -1,4 +1,4 @@
-export { default } from "./profile";
+//export { default } from "./profile";
 
 // import type { NextApiRequest, NextApiResponse } from "next";
 // import { prisma } from "@/lib/prisma";

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -1,74 +1,106 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { prisma } from "@/lib/prisma";
-// แปลงจาก custom middleware เป็น NextAuth - Convert from custom middleware to NextAuth
-// import { requireAuth, type AuthenticatedRequest } from "@/middlewares/auth"; // ลบออกเพราะไม่มีไฟล์นี้ - Remove because file doesn't exist
 import { getServerSession } from "next-auth";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
 import { authOptions } from "../auth/[...nextauth]";
 
-/*
-วิธีใช้ endpoint นี้ใน client page - How to use this endpoint in client page:
+/* ---- Validation Schema ---- */
+const updateProfileSchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  email: z.string().trim().email().optional(),
+  phone: z
+    .string()
+    .trim()
+    .regex(/^\d{9,15}$/, "phone must be 9–15 digits")
+    .optional(),
+  dob: z
+    .string()
+    .trim()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "dob must be YYYY-MM-DD")
+    .optional(),
+  profileImage: z.string().url().optional(),
+});
 
-1. ในหน้า page ต้อง import useSession - In page component, import useSession:
-   import { useSession } from "next-auth/react";
 
-2. เช็ค authentication status:
-   const { data: session, status } = useSession();
-   if (status === 'loading') return <div>Loading...</div>;
-   if (!session) return <div>Please login</div>;
-
-3. เรียก API ได้เลย ไม่ต้องส่ง token เพราะ NextAuth จัดการให้:
-   const response = await fetch('/api/user/profile');
-   // หรือใช้ axios: await axios.get('/api/user/profile');
-
-4. NextAuth จะส่ง HttpOnly cookies ไปกับทุก request อัตโนมัติ
-   ไม่ต้องจัดการ Authorization header เอง
-
-ตัวอย่างการใช้ใน page component:
-const Profile = () => {
-  const { data: session, status } = useSession();
-  const [profile, setProfile] = useState(null);
-
-  useEffect(() => {
-    if (session) {
-      fetch('/api/user/profile')
-        .then(res => res.json())
-        .then(data => setProfile(data));
-    }
-  }, [session]);
-
-  if (status === 'loading') return <div>Loading...</div>;
-  if (!session) return <div>Please login</div>;
-
-  return <div>{profile?.name}</div>;
+type UserProfileResponse = {
+  name: string;
+  email: string;
+  phone: string;
+  dob: string;
+  profileImage: string;
 };
-*/
 
-// แปลงจาก requireAuth wrapper เป็น standard async function - Convert from requireAuth wrapper to standard async function
-// export default requireAuth(async function handler(
-//   req: AuthenticatedRequest,
-//   res: NextApiResponse
-// ) {
-export default async function handler(
+type UpdateResponse = { message: string };
+type ValidationDetails = z.inferFlattenedErrors<typeof updateProfileSchema>;
+
+type ErrorResponse = {
+  error: string;
+  details?: ValidationDetails;
+  fields?: string[];
+};
+
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
+  METHOD_NOT_ALLOWED: 405,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+const ERROR_MESSAGES = {
+  UNAUTHORIZED: "Unauthorized",
+  INVALID_USER_ID: "Invalid user id",
+  USER_NOT_FOUND: "User not found",
+  VALIDATION_ERROR: "Validation error",
+  METHOD_NOT_ALLOWED: "Method not allowed",
+  EMAIL_TAKEN: "email_taken",
+  PHONE_TAKEN: "phone_taken",
+  UNIQUE_VIOLATION: "unique_violation",
+  INTERNAL_SERVER_ERROR: "Internal Server Error",
+} as const;
+
+const SUCCESS_MESSAGES = {
+  PROFILE_UPDATED: "OK",
+} as const;
+
+
+const getUserIdFromSession = async (
   req: NextApiRequest,
   res: NextApiResponse
-) {
-  // NextAuth: ดึง session จาก cookies โดยอัตโนมัติ - ไม่ต้องส่ง token มาเอง
-  // NextAuth: getServerSession จะอ่าน HttpOnly cookies และ decode JWT ให้เราเลย
+): Promise<number | null> => {
   const session = await getServerSession(req, res, authOptions);
+  const userIdStr = session?.user?.id;
+  if (!userIdStr) return null;
+  const userId = Number(userIdStr);
+  return Number.isFinite(userId) ? userId : null;
+};
 
-  // เช็คว่ามี session และ user id หรือไม่ - Check if session and user id exist
-  if (!session?.user?.id) {
-    return res.status(401).json({ error: "Unauthorized" });
-  }
+const isPrismaUniqueConstraintError = (
+  error: unknown
+): error is Prisma.PrismaClientKnownRequestError =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error as { code: unknown }).code === "P2002";
 
-  // NextAuth: session.user.id มาจาก JWT token ที่ถูก decode แล้ว
-  // NextAuth: ข้อมูลนี้มาจาก callbacks.session ใน [...nextauth].ts
-  // const userId = req.user!.id; // เก่า - old way with custom middleware
-  const userId = session.user.id; // NextAuth way
+const formatDateForResponse = (date: Date | null): string =>
+  date ? date.toISOString().slice(0, 10) : "";
 
-  if (req.method === "GET") {
-    const user = await prisma.user.findUnique({
-      where: { id: Number(userId) },
+const parseDate = (dateString: string): Date =>
+  new Date(`${dateString}T00:00:00.000Z`);
+
+
+type UpdateData = Parameters<typeof prisma.user.update>[0]["data"];
+
+const userRepository = {
+  findById: async (userId: number) => {
+    return prisma.user.findUnique({
+      where: { id: userId },
       select: {
         id: true,
         name: true,
@@ -78,41 +110,118 @@ export default async function handler(
         profile_image: true,
       },
     });
-    if (!user) return res.status(404).json({ error: "User not found" });
+  },
 
-    return res.status(200).json({
-      name: user.name ?? "",
-      email: user.email ?? "",
-      phone: user.phone ?? "",
-      dob: user.dob ? user.dob.toISOString().slice(0, 10) : "",
-      profileImage: user.profile_image ?? "",
+  updateById: async (userId: number, data: UpdateData) => {
+    return prisma.user.update({
+      where: { id: userId },
+      data: { ...data, updated_at: new Date() },
+    });
+  },
+};
+
+
+const handleGetProfile = async (
+  userId: number,
+  res: NextApiResponse<UserProfileResponse | ErrorResponse>
+) => {
+  const user = await userRepository.findById(userId);
+  if (!user) {
+    return res.status(HTTP_STATUS.NOT_FOUND).json({
+      error: ERROR_MESSAGES.USER_NOT_FOUND,
     });
   }
 
-  if (req.method === "PUT") {
-    const { name, email, phone, dob, profileImage } = req.body as {
-      name?: string;
-      email?: string;
-      phone?: string;
-      dob?: string; // "YYYY-MM-DD"
-      profileImage?: string;
-    };
+  return res.status(HTTP_STATUS.OK).json({
+    name: user.name ?? "",
+    email: user.email ?? "",
+    phone: user.phone ?? "",
+    dob: formatDateForResponse(user.dob),
+    profileImage: user.profile_image ?? "",
+  });
+};
 
-    await prisma.user.update({
-      where: { id: Number(userId) },
-      data: {
-        name: name ?? undefined,
-        email: email ?? undefined,
-        phone: phone ?? undefined,
-        dob: dob ? new Date(dob) : undefined,
-        profile_image: profileImage ?? undefined,
-        updated_at: new Date(),
-      },
+const handleUpdateProfile = async (
+  userId: number,
+  req: NextApiRequest,
+  res: NextApiResponse<UpdateResponse | ErrorResponse>
+) => {
+  const validation = updateProfileSchema.safeParse(req.body);
+  if (!validation.success) {
+    return res.status(HTTP_STATUS.BAD_REQUEST).json({
+      error: ERROR_MESSAGES.VALIDATION_ERROR,
+      details: validation.error.flatten(),
     });
-
-    return res.status(200).json({ message: "OK" });
   }
 
-  res.setHeader("Allow", ["GET", "PUT"]);
-  return res.status(405).json({ error: "Method not allowed" });
+  const { name, email, phone, dob, profileImage } = validation.data;
+
+  const updateData: UpdateData = {};
+  if (name !== undefined) updateData.name = name;
+  if (email !== undefined) updateData.email = email;
+  if (phone !== undefined) updateData.phone = phone;
+  if (dob !== undefined) updateData.dob = parseDate(dob);
+  if (profileImage !== undefined) updateData.profile_image = profileImage;
+
+  try {
+    await userRepository.updateById(userId, updateData);
+    return res.status(HTTP_STATUS.OK).json({
+      message: SUCCESS_MESSAGES.PROFILE_UPDATED,
+    });
+  } catch (error) {
+    if (isPrismaUniqueConstraintError(error)) {
+      const target = Array.isArray(error.meta?.target)
+        ? (error.meta!.target as string[])
+        : undefined;
+
+      if (target?.includes("email")) {
+        return res.status(HTTP_STATUS.CONFLICT).json({
+          error: ERROR_MESSAGES.EMAIL_TAKEN,
+        });
+      }
+      if (target?.includes("phone")) {
+        return res.status(HTTP_STATUS.CONFLICT).json({
+          error: ERROR_MESSAGES.PHONE_TAKEN,
+        });
+      }
+
+      return res.status(HTTP_STATUS.CONFLICT).json({
+        error: ERROR_MESSAGES.UNIQUE_VIOLATION,
+        fields: target,
+      });
+    }
+
+    throw error;
+  }
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<UserProfileResponse | UpdateResponse | ErrorResponse>
+) {
+  try {
+    const userId = await getUserIdFromSession(req, res);
+    if (!userId) {
+      return res.status(HTTP_STATUS.UNAUTHORIZED).json({
+        error: ERROR_MESSAGES.UNAUTHORIZED,
+      });
+    }
+
+    switch (req.method) {
+      case "GET":
+        return handleGetProfile(userId, res);
+      case "PUT":
+        return handleUpdateProfile(userId, req, res);
+      default:
+        res.setHeader("Allow", ["GET", "PUT"]);
+        return res.status(HTTP_STATUS.METHOD_NOT_ALLOWED).json({
+          error: ERROR_MESSAGES.METHOD_NOT_ALLOWED,
+        });
+    }
+  } catch (error) {
+    console.error("Profile API error:", error);
+    return res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).json({
+      error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+    });
+  }
 }

--- a/src/pages/api/user/put-owner.ts
+++ b/src/pages/api/user/put-owner.ts
@@ -1,1 +1,0 @@
-export { default } from "./profile";

--- a/src/pages/api/user/unique-check.ts
+++ b/src/pages/api/user/unique-check.ts
@@ -1,0 +1,223 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import { prisma } from "@/lib/prisma";
+
+
+type UniqueCheckField = "email" | "name" | "phone";
+
+type RequestBody =
+  | {
+      field: UniqueCheckField;
+      value: string;
+    }
+  | {
+      email?: string;
+      name?: string;
+      phone?: string;
+    };
+
+type UniqueResponse = {
+  unique: boolean;
+};
+
+type ErrorResponse = {
+  error: string;
+};
+
+
+const HTTP_STATUS = {
+  OK: 200,
+  METHOD_NOT_ALLOWED: 405,
+  BAD_REQUEST: 400,
+} as const;
+
+const ERROR_MESSAGES = {
+  METHOD_NOT_ALLOWED: "Method not allowed",
+  INVALID_FIELD: "Invalid field specified",
+  MISSING_VALUE: "Value is required",
+} as const;
+
+
+const sanitizeInput = {
+  email: (value: string): string => value.trim().toLowerCase(),
+  name: (value: string): string => value.trim(),
+  phone: (value: string): string => value.replace(/\D/g, ""),
+};
+
+const getCurrentUserId = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<number | undefined> => {
+  const session = await getServerSession(req, res, authOptions);
+  return session?.user?.id ? Number(session.user.id) : undefined;
+};
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+
+/**
+ * แปลง/ตรวจรูปแบบ body จาก unknown  RequestBody
+ */
+const parseRequestBody = (body: unknown): RequestBody | null => {
+  if (!isRecord(body)) return null;
+
+  if (
+    "field" in body &&
+    "value" in body &&
+    typeof body.field === "string" &&
+    typeof body.value === "string"
+  ) {
+    const f = body.field as string;
+    if (f === "email" || f === "name" || f === "phone") {
+      return { field: f, value: body.value } as RequestBody;
+    }
+  }
+
+  const email = typeof body.email === "string" ? body.email : undefined;
+  const name = typeof body.name === "string" ? body.name : undefined;
+  const phone = typeof body.phone === "string" ? body.phone : undefined;
+  if (email !== undefined || name !== undefined || phone !== undefined) {
+    return { email, name, phone };
+  }
+
+  return null;
+};
+
+const processRequest = (
+  body: RequestBody
+): { field: UniqueCheckField; value: string } | null => {
+  if ("field" in body && "value" in body) {
+    return { field: body.field, value: body.value };
+  }
+
+  if ("email" in body && body.email) {
+    return { field: "email", value: body.email };
+  }
+  if ("name" in body && body.name) {
+    return { field: "name", value: body.name };
+  }
+  if ("phone" in body && body.phone) {
+    return { field: "phone", value: body.phone };
+  }
+  return null;
+};
+
+const validateAndSanitize = (
+  field: UniqueCheckField,
+  value: string
+): string | null => {
+  if (!value?.trim()) return null;
+  const sanitizedValue = sanitizeInput[field](value);
+  return sanitizedValue || null;
+};
+
+
+const uniqueCheckRepository = {
+  checkEmail: async (
+    email: string,
+    excludeUserId?: number
+  ): Promise<boolean> => {
+    const found = await prisma.user.findFirst({
+      where: {
+        email,
+        ...(excludeUserId ? { NOT: { id: excludeUserId } } : {}),
+      },
+      select: { id: true },
+    });
+    return !found;
+  },
+
+  checkName: async (name: string, excludeUserId?: number): Promise<boolean> => {
+    const found = await prisma.user.findFirst({
+      where: {
+        name,
+        ...(excludeUserId ? { NOT: { id: excludeUserId } } : {}),
+      },
+      select: { id: true },
+    });
+    return !found;
+  },
+
+  checkPhone: async (
+    phone: string,
+    excludeUserId?: number
+  ): Promise<boolean> => {
+    const found = await prisma.user.findFirst({
+      where: {
+        phone,
+        ...(excludeUserId ? { NOT: { id: excludeUserId } } : {}),
+      },
+      select: { id: true },
+    });
+    return !found;
+  },
+};
+
+/* ---- Main Handler ---- */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<UniqueResponse | ErrorResponse>
+) {
+  // Method validation
+  if (req.method !== "POST") {
+    return res.status(HTTP_STATUS.METHOD_NOT_ALLOWED).json({
+      error: ERROR_MESSAGES.METHOD_NOT_ALLOWED,
+    });
+  }
+
+  try {
+    const parsed = parseRequestBody(req.body);
+    const requestData = parsed ? processRequest(parsed) : null;
+
+    if (!requestData) {
+      return res
+        .status(HTTP_STATUS.BAD_REQUEST)
+        .json({ error: ERROR_MESSAGES.MISSING_VALUE });
+    }
+
+    const { field, value } = requestData;
+
+
+    const sanitizedValue = validateAndSanitize(field, value);
+    if (!sanitizedValue) {
+      // ค่าว่างถือว่า "unique" (ไม่มีอะไรให้ชน)
+      return res.status(HTTP_STATUS.OK).json({ unique: true });
+    }
+
+
+    const currentUserId = await getCurrentUserId(req, res);
+
+
+    let isUnique: boolean;
+    switch (field) {
+      case "email":
+        isUnique = await uniqueCheckRepository.checkEmail(
+          sanitizedValue,
+          currentUserId
+        );
+        break;
+      case "name":
+        isUnique = await uniqueCheckRepository.checkName(
+          sanitizedValue,
+          currentUserId
+        );
+        break;
+      case "phone":
+        isUnique = await uniqueCheckRepository.checkPhone(
+          sanitizedValue,
+          currentUserId
+        );
+        break;
+      default:
+        return res
+          .status(HTTP_STATUS.BAD_REQUEST)
+          .json({ error: ERROR_MESSAGES.INVALID_FIELD });
+    }
+
+    return res.status(HTTP_STATUS.OK).json({ unique: isUnique });
+  } catch (error) {
+    console.error("Unique check API error:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/src/pages/componentall.tsx
+++ b/src/pages/componentall.tsx
@@ -448,7 +448,6 @@ export default function ComponentAll() {
     */}
             <div className="space-y-3 rounded-2xl border border-dashed border-purple-300 p-5">
               <h3 className="text-lg font-semibold text-ink/90">Pet Sitter – Large</h3>
-              <p className="text-gray-500 text-sm -mt-1">ขาดขนาดรูป large ต้องแก้</p>
 
               {/* Desktop: รูปซ้าย (ปกติ + มีกรอบส้ม) */}
               <div className="hidden md:block w-[848px] mx-auto space-y-4">

--- a/src/types/pet.types.ts
+++ b/src/types/pet.types.ts
@@ -1,18 +1,110 @@
+export type PetTypeEnum = "Dog" | "Cat" | "Bird" | "Rabbit" | "Other";
+export type PetSex = "Male" | "Female";
+
+
 export type Pet = {
-    id: number;
-    name: string;
-    type: "Dog" | "Cat" | "Bird" | "Other";
-    image?: string;
-  };
-  
-  export type PetFormValues = {
-    name: string;
-    type: string;
-    breed: string;
-    sex: string;
-    ageMonth: string;
-    color: string;
-    weightKg: string;
-    about: string;
-    image?: string;
-  };
+  id: number;
+  name: string;
+  petTypeName?: string;
+  breed?: string;
+  sex?: PetSex | "" | null;
+  ageMonth?: number | null;
+  color?: string;
+  weightKg?: number | null;
+  about?: string;
+  imageUrl?: string | null;
+};
+
+export type PetType = { 
+  id: number; 
+  name: string; 
+};
+
+/* ---- Form Types ---- */
+export type PetFormValues = {
+  name: string;
+  type: string;
+  breed: string;
+  sex: string;
+  ageMonth: string;
+  color: string;
+  weightKg: string;
+  about: string;
+  image: string;
+};
+
+
+export type PetResponse = {
+  id: number;
+  name: string | null;
+  petTypeName: string | null;
+  breed: string | null;
+  sex: PetSex | "" | null;
+  ageMonth: number | null;
+  color: string | null;
+  weightKg: number | null;
+  about: string | null;
+  imageUrl: string | null;
+};
+
+export type PetCreatePayload = {
+  petTypeId: number;
+  name: string;
+  breed: string;
+  sex: PetSex;
+  ageMonth: number;
+  color: string;
+  weightKg: number;
+  about: string;
+  imageUrl: string;
+};
+
+export type PetUpdatePayload = Partial<PetCreatePayload>;
+
+
+export type PetCardData = {
+  id: number;
+  name: string;
+  type: string;
+  image?: string;
+};
+
+export type PetListItem = {
+  id: number;
+  name: string;
+  petTypeName?: string;
+  imageUrl?: string | null;
+};
+
+
+export const PET_TYPES: readonly PetTypeEnum[] = [
+  "Dog",
+  "Cat", 
+  "Bird",
+  "Rabbit",
+  "Other"
+] as const;
+
+export const PET_SEXES: readonly PetSex[] = [
+  "Male",
+  "Female"
+] as const;
+
+
+export const isPetType = (value: string): value is PetTypeEnum => {
+  return PET_TYPES.includes(value as PetTypeEnum);
+};
+
+export const isPetSex = (value: string): value is PetSex => {
+  return PET_SEXES.includes(value as PetSex);
+};
+
+
+export type PetWithOwner = Pet & {
+  ownerId: number;
+  ownerName?: string;
+};
+
+export type PetFormData = Omit<PetFormValues, 'image'> & {
+  image?: File | string;
+};


### PR DESCRIPTION
ย้าย UI core shadcn/ui + Tailwind (แทน MUI Tabs)
เพิ่ม AccountPageShell เป็น layout กลางของ /account/* 
รีแฟคเตอร์การ์ด: PetCard (รองรับ id/onClickId), BookingCard, PetSitterCard, CreateNewPetCard
ทำ Pet CRUD ครบ: list / create / edit / delete + ConfirmModal + PageToaster
Map type (string) -petTypeId (number) ก่อนยิง API (กันข้อมูลเพี้ยน)
โปรไฟล์: ใช้ RHF + Zod + /api/user/unique-check (exclude ตัวเอง)
Perf: ใส่ React.memo + useCallback + useMemo ในคอมโพเนนต์ที่เรียกบ่อย
UX: ใส่ cursor-pointer ทุกปุ่ม/label ที่คลิกได้

